### PR TITLE
Sitemap refactoring

### DIFF
--- a/udata/core/dataset/views.py
+++ b/udata/core/dataset/views.py
@@ -17,6 +17,7 @@ from udata.models import Dataset, Resource, Reuse, Issue, DatasetDiscussion, Fol
 
 from udata.core import storages
 from udata.core.site.views import current_site
+from udata.sitemap import sitemap
 
 from .forms import DatasetForm, ResourceForm, CommunityResourceForm, DatasetExtraForm
 from .permissions import CommunityResourceEditPermission, DatasetEditPermission
@@ -315,3 +316,9 @@ class DatasetFollowersView(DatasetView, DetailView):
         context = super(DatasetFollowersView, self).get_context()
         context['followers'] = Follow.objects.followers(self.dataset).order_by('follower.fullname')
         return context
+
+
+@sitemap.register_generator
+def sitemap_urls():
+    for dataset in Dataset.objects.visible():
+        yield 'datasets.show_redirect', {'dataset': dataset.id}, None, "weekly", 1

--- a/udata/core/organization/views.py
+++ b/udata/core/organization/views.py
@@ -18,6 +18,7 @@ from udata.models import (
     db, Organization, Member, Reuse, Dataset, ORG_ROLES, User, Issue, FollowOrg,
     DatasetIssue, DatasetDiscussion
 )
+from udata.sitemap import sitemap
 from udata.utils import get_by
 
 from udata.core.dataset.csv import (
@@ -335,3 +336,9 @@ def supplied_datasets_resources_csv(org):
     datasets = search.iter(Dataset, supplier=str(org.id))
     adapter = ResourcesCsvAdapter(datasets)
     return csv.stream(adapter, '{0}-supplied-datasets-resources'.format(org.slug))
+
+
+@sitemap.register_generator
+def sitemap_urls():
+    for org in Organization.objects.visible():
+        yield 'organizations.show_redirect', {'org': org}, None, "weekly", 0.8

--- a/udata/core/post/views.py
+++ b/udata/core/post/views.py
@@ -8,6 +8,8 @@ from udata.frontend.views import CreateView, EditView
 
 from udata.models import Post
 
+from udata.sitemap import sitemap
+
 from .forms import PostForm
 from .permissions import PostEditPermission
 
@@ -48,3 +50,9 @@ class PostCreateView(ProtectedPostView, CreateView):
 class PostEditView(ProtectedPostView, EditView):
     form = PostForm
     template_name = 'post/edit.html'
+
+
+@sitemap.register_generator
+def sitemap_urls():
+    for post in Post.objects(private=False):
+        yield 'posts.show_redirect', {'post': post.slug}, None, "weekly", 0.5

--- a/udata/core/reuse/views.py
+++ b/udata/core/reuse/views.py
@@ -12,6 +12,7 @@ from udata.app import nav
 from udata.frontend.views import SearchView, DetailView, CreateView, EditView, SingleObject, BaseView
 from udata.i18n import I18nBlueprint, lazy_gettext as _
 from udata.models import Issue, FollowReuse, Dataset
+from udata.sitemap import sitemap
 
 from .forms import ReuseForm, AddDatasetToReuseForm
 from .models import Reuse, ReuseDiscussion
@@ -172,3 +173,9 @@ class ReuseIssuesView(ProtectedReuseView, DetailView):
 class ReuseTransferView(ProtectedReuseView, EditView):
     form = ReuseForm
     template_name = 'reuse/transfer.html'
+
+
+@sitemap.register_generator
+def sitemap_urls():
+    for reuse in Reuse.objects.visible():
+        yield 'reuses.show_redirect', {'reuse': reuse}, None, "weekly", 0.8

--- a/udata/core/topic/views.py
+++ b/udata/core/topic/views.py
@@ -4,10 +4,11 @@ from __future__ import unicode_literals
 from flask import g, request
 
 from udata import search, theme
+from udata.frontend.views import CreateView, EditView
 from udata.i18n import I18nBlueprint
 from udata.models import Topic, Reuse, Dataset
+from udata.sitemap import sitemap
 from udata.utils import multi_to_dict
-from udata.frontend.views import CreateView, EditView
 
 from .forms import TopicForm
 from .permissions import TopicEditPermission
@@ -96,3 +97,9 @@ class TopicEditView(ProtectedTopicView, EditView):
 @blueprint.before_app_request
 def store_featured_topics():
     g.featured_topics = sorted(Topic.objects(featured=True), key=lambda t: t.slug)
+
+
+@sitemap.register_generator
+def sitemap_urls():
+    for topic in Topic.objects:
+        yield 'topics.display_redirect', {'topic': topic}, None, "weekly", 0.8

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -67,6 +67,8 @@ class Testing(Defaults):
     TEST_WITH_THEME = False
     ASSETS_AUTO_BUILD = False
     ASSETS_DEBUG = True
+    CACHE_TYPE = 'null'
+    CACHE_NO_NULL_WARNING = True
 
 
 class Debug(Defaults):

--- a/udata/sitemap.py
+++ b/udata/sitemap.py
@@ -11,18 +11,14 @@ sitemap = Sitemap()
 
 @sitemap_page_needed.connect
 def create_page(app, page, urlset):
-    cache[page] = sitemap.render_page(urlset=urlset)
+    cache.set(page, sitemap.render_page(urlset=urlset))
 
 
 def load_page(fn):
     @wraps(fn)
     def loader(*args, **kwargs):
         page = kwargs.get('page')
-        try:
-            data = cache.get(page)
-        except KeyError:
-            data = None
-        return data if data else fn(*args, **kwargs)
+        return cache.get(page) or fn(*args, **kwargs)
     return loader
 
 

--- a/udata/sitemap.py
+++ b/udata/sitemap.py
@@ -24,5 +24,5 @@ def load_page(fn):
 
 def init_app(app):
     app.config['SITEMAP_VIEW_DECORATORS'] = [load_page]
-    app.config['SITEMAP_URL_METHOD'] = 'https'
+    app.config['SITEMAP_URL_METHOD'] = 'https' if app.config['USE_SSL'] else 'http'
     sitemap.init_app(app)

--- a/udata/sitemap.py
+++ b/udata/sitemap.py
@@ -1,43 +1,32 @@
+from __future__ import unicode_literals
+
 from functools import wraps
 from flask.ext.sitemap import Sitemap, sitemap_page_needed
-from flask.ext.cache import Cache
 
-from core.dataset.models import Dataset
-from core.reuse.models import Reuse
-from core.organization.models import Organization
-from core.topic.models import Topic
+from udata.app import cache
+
+
+sitemap = Sitemap()
+
+
+@sitemap_page_needed.connect
+def create_page(app, page, urlset):
+    cache[page] = sitemap.render_page(urlset=urlset)
+
+
+def load_page(fn):
+    @wraps(fn)
+    def loader(*args, **kwargs):
+        page = kwargs.get('page')
+        try:
+            data = cache.get(page)
+        except KeyError:
+            data = None
+        return data if data else fn(*args, **kwargs)
+    return loader
 
 
 def init_app(app):
-    cache = Cache()
-    sitemap = Sitemap()
-
-    @sitemap_page_needed.connect
-    def create_page(app, page, urlset):
-        cache[page] = sitemap.render_page(urlset=urlset)
-
-    def load_page(fn):
-        @wraps(fn)
-        def loader(*args, **kwargs):
-            page = kwargs.get('page')
-            try:
-                data = cache.get(page)
-            except KeyError:
-                data = None
-            return data if data else fn(*args, **kwargs)
-        return loader
-
-    @sitemap.register_generator
-    def collect_urls():
-        for item in Dataset.objects.visible():
-            yield 'datasets.show_redirect', {'dataset': item.id}, None, "weekly", 1
-        for item in Reuse.objects.visible():
-            yield 'reuses.show_redirect', {'reuse': item}, None, "weekly", 0.8
-        for item in Organization.objects.visible():
-            yield 'organizations.show_redirect', {'org': item}, None, "weekly", 0.8
-        for item in Topic.objects.all():
-            yield 'topics.display_redirect', {'topic': item}, None, "weekly", 0.8
-
     app.config['SITEMAP_VIEW_DECORATORS'] = [load_page]
     app.config['SITEMAP_URL_METHOD'] = 'https'
     sitemap.init_app(app)

--- a/udata/sitemap.py
+++ b/udata/sitemap.py
@@ -23,6 +23,7 @@ def load_page(fn):
 
 
 def init_app(app):
+    sitemap.decorators = []
     app.config['SITEMAP_VIEW_DECORATORS'] = [load_page]
     app.config['SITEMAP_URL_METHOD'] = 'https' if app.config['USE_SSL'] else 'http'
     sitemap.init_app(app)

--- a/udata/tests/factories.py
+++ b/udata/tests/factories.py
@@ -226,6 +226,7 @@ class PostFactory(MongoEngineFactory):
     name = factory.LazyAttribute(lambda o: faker.sentence())
     headline = factory.LazyAttribute(lambda o: faker.sentence())
     content = factory.LazyAttribute(lambda o: faker.text())
+    private = factory.LazyAttribute(lambda o: False)
 
     @factory.lazy_attribute
     def datasets(self):

--- a/udata/tests/test_sitemap.py
+++ b/udata/tests/test_sitemap.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals
 from udata import frontend
 from udata.tests import TestCase, WebTestMixin, SearchTestMixin
 
-from .factories import TopicFactory, OrganizationFactory, VisibleReuseFactory, VisibleDatasetFactory
+from .factories import TopicFactory, PostFactory, OrganizationFactory, VisibleReuseFactory, VisibleDatasetFactory
 
 
 class SitemapTestCase(WebTestMixin, SearchTestMixin, TestCase):
@@ -63,4 +63,16 @@ class SitemapTest(SitemapTestCase):
         self.assertIn('<changefreq>weekly</changefreq>', response.data)
         self.assertIn(
             '<loc>http://localhost/datasets/{dataset}/</loc>'.format(dataset=datasets[0].id),
+            response.data)
+
+    def test_posts_within_sitemap(self):
+        '''It should return a post list from the sitemap.'''
+        posts = PostFactory.create_batch(3)
+        response = self.get('sitemap.xml')
+        self.assert200(response)
+        self.assertEqual(response.data.count('<loc>'), 3, response.data)
+        self.assertIn('<priority>0.5</priority>', response.data)
+        self.assertIn('<changefreq>weekly</changefreq>', response.data)
+        self.assertIn(
+            '<loc>http://localhost/posts/{post}/</loc>'.format(post=posts[0].slug),
             response.data)


### PR DESCRIPTION
A little refactoring including:

- Allow each module to register its own URLs to the sitemap (by making the sitemap instance global)
- Fix cache handling during tests
- Reuse the application-wide cache
- Only use https in URLs when ``USE_SSL`` setting is set
- Avoid reaching maximum recursion depth during tests
- Add the posts to the sitemap