### PR TITLE
Make markdown supported tags configurable with sane defaults

### DIFF
--- a/udata/frontend/markdown.py
+++ b/udata/frontend/markdown.py
@@ -42,7 +42,8 @@ class UDataMarkdown(object):
         ast = self.parser.parse(stream)
         html = self.renderer.render(ast)
         # Turn string links into HTML ones *after* markdown transformation.
-        html = bleach.linkify(html, tokenizer=KeepTokenSanitizer, skip_pre=True)
+        html = bleach.linkify(html, tokenizer=KeepTokenSanitizer,
+                              skip_pre=True, parse_email=True)
         # Return a `Markup` element considered as safe by Jinja.
         return Markup(html)
 

--- a/udata/frontend/markdown.py
+++ b/udata/frontend/markdown.py
@@ -33,7 +33,11 @@ class UDataMarkdown(object):
             return ''
         # Sanitize malicious attempts but keep the `EXCERPT_TOKEN`.
         # By default, only keeps `bleach.ALLOWED_TAGS`.
-        stream = bleach.clean(stream, strip_comments=False)
+        stream = bleach.clean(stream,
+                              tags=current_app.config['MD_ALLOWED_TAGS'],
+                              attributes=current_app.config['MD_ALLOWED_ATTRIBUTES'],
+                              styles=current_app.config['MD_ALLOWED_STYLES'],
+                              strip_comments=False)
         # Turn markdown to HTML.
         ast = self.parser.parse(stream)
         html = self.renderer.render(ast)

--- a/udata/frontend/markdown.py
+++ b/udata/frontend/markdown.py
@@ -42,7 +42,7 @@ class UDataMarkdown(object):
         ast = self.parser.parse(stream)
         html = self.renderer.render(ast)
         # Turn string links into HTML ones *after* markdown transformation.
-        html = bleach.linkify(html, tokenizer=KeepTokenSanitizer)
+        html = bleach.linkify(html, tokenizer=KeepTokenSanitizer, skip_pre=True)
         # Return a `Markup` element considered as safe by Jinja.
         return Markup(html)
 

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -56,6 +56,34 @@ class Defaults(object):
 
     OAUTH2_PROVIDER_ERROR_ENDPOINT = 'oauth-i18n.oauth_error'
 
+    MD_ALLOWED_TAGS = [
+        'a',
+        'abbr',
+        'acronym',
+        'b',
+        'br',
+        'blockquote',
+        'code',
+        'dl',
+        'dt',
+        'em',
+        'i',
+        'li',
+        'ol',
+        'pre',
+        'small',
+        'strong',
+        'ul',
+    ]
+
+    MD_ALLOWED_ATTRIBUTES = {
+        'a': ['href', 'title'],
+        'abbr': ['title'],
+        'acronym': ['title'],
+    }
+
+    MD_ALLOWED_STYLES = []
+
     # CROQUEMORT = {
     #     'url': 'http://localhost:8000',
     #     'delay': 1,

--- a/udata/tests/frontend/test_markdown.py
+++ b/udata/tests/frontend/test_markdown.py
@@ -63,14 +63,14 @@ class MarkdownTestCase(TestCase, WebTestMixin):
             self.assertEqual(el.getAttribute('href'), 'mailto:coucou@cmoi.fr')
             self.assertEqual(el.firstChild.data, 'coucou@cmoi.fr')
 
-    def test_markdown_linkify_wihtin_pre(self):
+    def test_markdown_linkify_within_pre(self):
         '''Markdown filter should not transform urls into <pre> anchors'''
         text = '<pre>http://example.net/</pre>'
         with self.app.test_request_context('/'):
             result = render_template_string('{{ text|markdown }}', text=text)
             self.assertEqual(result.strip(), '<pre>http://example.net/</pre>')
 
-    def test_markdown_linkify_email_wihtin_pre(self):
+    def test_markdown_linkify_email_within_pre(self):
         '''Markdown filter should not transform emails into <pre> anchors'''
         text = '<pre>coucou@cmoi.fr</pre>'
         with self.app.test_request_context('/'):

--- a/udata/tests/frontend/test_markdown.py
+++ b/udata/tests/frontend/test_markdown.py
@@ -53,12 +53,29 @@ class MarkdownTestCase(TestCase, WebTestMixin):
             self.assertEqual(el.getAttribute('href'), 'http://example.net/')
             self.assertEqual(el.firstChild.data, 'http://example.net/')
 
+    def test_markdown_linkify_mails(self):
+        '''Markdown filter should transform emails to anchors'''
+        text = 'coucou@cmoi.fr'
+        with self.app.test_request_context('/'):
+            result = render_template_string('{{ text|markdown }}', text=text)
+            parsed = parser.parse(result)
+            el = parsed.getElementsByTagName('a')[0]
+            self.assertEqual(el.getAttribute('href'), 'mailto:coucou@cmoi.fr')
+            self.assertEqual(el.firstChild.data, 'coucou@cmoi.fr')
+
     def test_markdown_linkify_wihtin_pre(self):
         '''Markdown filter should not transform urls into <pre> anchors'''
         text = '<pre>http://example.net/</pre>'
         with self.app.test_request_context('/'):
             result = render_template_string('{{ text|markdown }}', text=text)
             self.assertEqual(result.strip(), '<pre>http://example.net/</pre>')
+
+    def test_markdown_linkify_email_wihtin_pre(self):
+        '''Markdown filter should not transform emails into <pre> anchors'''
+        text = '<pre>coucou@cmoi.fr</pre>'
+        with self.app.test_request_context('/'):
+            result = render_template_string('{{ text|markdown }}', text=text)
+            self.assertEqual(result.strip(), '<pre>coucou@cmoi.fr</pre>')
 
     def test_bleach_sanitize(self):
         '''Markdown filter should sanitize evil code'''

--- a/udata/tests/frontend/test_markdown.py
+++ b/udata/tests/frontend/test_markdown.py
@@ -53,6 +53,13 @@ class MarkdownTestCase(TestCase, WebTestMixin):
             self.assertEqual(el.getAttribute('href'), 'http://example.net/')
             self.assertEqual(el.firstChild.data, 'http://example.net/')
 
+    def test_markdown_linkify_wihtin_pre(self):
+        '''Markdown filter should not transform urls into <pre> anchors'''
+        text = '<pre>http://example.net/</pre>'
+        with self.app.test_request_context('/'):
+            result = render_template_string('{{ text|markdown }}', text=text)
+            self.assertEqual(result.strip(), '<pre>http://example.net/</pre>')
+
     def test_bleach_sanitize(self):
         '''Markdown filter should sanitize evil code'''
         text = 'an <script>evil()</script>'


### PR DESCRIPTION
This PR make markdown allowed tags configurables and provide larger default than bleach defaults.