### PR TITLE
Emit signals on Dataset.add_resource

### DIFF
--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -5,7 +5,7 @@ import datetime
 
 from collections import OrderedDict
 
-from blinker import Signal
+from blinker import signal
 from flask import url_for
 from mongoengine.signals import pre_save, post_save
 
@@ -126,8 +126,8 @@ class Resource(WithMetrics, db.EmbeddedDocument):
     published = db.DateTimeField(default=datetime.datetime.now, required=True)
     deleted = db.DateTimeField()
 
-    on_added = Signal()
-    on_deleted = Signal()
+    on_added = signal('Resource.on_added')
+    on_deleted = signal('Resource.on_deleted')
 
     def clean(self):
         super(Resource, self).clean()
@@ -184,13 +184,13 @@ class Dataset(WithMetrics, BadgeMixin, db.Datetimed, db.Document):
         'queryset_class': DatasetQuerySet,
     }
 
-    before_save = Signal()
-    after_save = Signal()
-    on_create = Signal()
-    on_update = Signal()
-    before_delete = Signal()
-    after_delete = Signal()
-    on_delete = Signal()
+    before_save = signal('Dataset.before_save')
+    after_save = signal('Dataset.after_save')
+    on_create = signal('Dataset.on_create')
+    on_update = signal('Dataset.on_update')
+    before_delete = signal('Dataset.before_delete')
+    after_delete = signal('Dataset.after_delete')
+    on_delete = signal('Dataset.on_delete')
 
     verbose_name = _('dataset')
 
@@ -249,6 +249,7 @@ class Dataset(WithMetrics, BadgeMixin, db.Datetimed, db.Document):
             }
         })
         self.reload()
+        post_save.send(self.__class__, document=self)
 
     def add_community_resource(self, resource):
         '''Perform an atomic prepend for a new resource'''
@@ -261,6 +262,7 @@ class Dataset(WithMetrics, BadgeMixin, db.Datetimed, db.Document):
             }
         })
         self.reload()
+        post_save.send(self.__class__, document=self)
 
 
 pre_save.connect(Dataset.pre_save, sender=Dataset)

--- a/udata/tests/__init__.py
+++ b/udata/tests/__init__.py
@@ -88,9 +88,11 @@ class TestCase(BaseTestCase):
 
         for signal, mock_handler in specs:
             signal.disconnect(mock_handler)
+            signal_name = getattr(signal, 'name', str(signal))
             self.assertTrue(
                 mock_handler.called,
-                'Signal "{0}" should have been emitted'.format(signal.name))
+                'Signal "{0}" should have been emitted'.format(signal_name)
+            )
 
 
 class WebTestMixin(object):

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals, absolute_import
 
+from mongoengine import post_save
+
 from udata.models import Dataset
 
 from .. import TestCase, DBTestMixin
@@ -51,11 +53,14 @@ class DatasetModelTest(TestCase, DBTestMixin):
         user = UserFactory()
         dataset = DatasetFactory(owner=user)
         resource = ResourceFactory()
+        expected_signals = post_save, Dataset.after_save, Dataset.on_update
 
-        dataset.add_resource(ResourceFactory())
+        with self.assert_emit(*expected_signals):
+            dataset.add_resource(ResourceFactory())
         self.assertEqual(len(dataset.resources), 1)
 
-        dataset.add_resource(resource)
+        with self.assert_emit(*expected_signals):
+            dataset.add_resource(resource)
         self.assertEqual(len(dataset.resources), 2)
         self.assertEqual(dataset.resources[0].id, resource.id)
 
@@ -75,10 +80,13 @@ class DatasetModelTest(TestCase, DBTestMixin):
         user = UserFactory()
         dataset = DatasetFactory(owner=user)
         resource = ResourceFactory()
+        expected_signals = post_save, Dataset.after_save, Dataset.on_update
 
-        dataset.add_community_resource(ResourceFactory())
+        with self.assert_emit(*expected_signals):
+            dataset.add_community_resource(ResourceFactory())
         self.assertEqual(len(dataset.community_resources), 1)
 
-        dataset.add_community_resource(resource)
+        with self.assert_emit(*expected_signals):
+            dataset.add_community_resource(resource)
         self.assertEqual(len(dataset.community_resources), 2)
         self.assertEqual(dataset.community_resources[0].id, resource.id)


### PR DESCRIPTION
This pull request fix some missing signals emission on `Dataset.add_resource` and `Dataset.add_community_resource`.
By extension, it fixes reindexation on these operations.