### PR TITLE
Improve the static collect command

### DIFF
--- a/udata/app.py
+++ b/udata/app.py
@@ -33,6 +33,9 @@ nav = Navigation()
 class UDataApp(Flask):
     debug_log_format = '[%(levelname)s][%(name)s:%(lineno)d] %(message)s'
 
+    # Keep track of static dirs given as register_blueprint argument
+    static_prefixes = {}
+
     def send_static_file(self, filename):
         '''
         Override default static handling:
@@ -66,6 +69,11 @@ class UDataApp(Flask):
         if 'error' not in g:
             g.error = e
         return super(UDataApp, self).handle_http_exception(e)
+
+    def register_blueprint(self, blueprint, **kwargs):
+        if blueprint.has_static_folder and 'url_prefix' in kwargs:
+            self.static_prefixes[blueprint.name] = kwargs['url_prefix']
+        return super(UDataApp, self).register_blueprint(blueprint, **kwargs)
 
 
 class Blueprint(BaseBlueprint):

--- a/udata/commands/static.py
+++ b/udata/commands/static.py
@@ -24,29 +24,45 @@ log = logging.getLogger(__name__)
 def collect(path, input):
     '''Collect static files'''
     if exists(path):
-        print('"{0}" directory already exists and will be erased'.format(path))
+        msg = '"%s" directory already exists and will be erased'
+        log.warning(msg, path)
         if input and not prompt_bool('Are you sure'):
             exit(-1)
 
-        print('Deleting static directory {0}'.format(path))
+        log.info('Deleting static directory "%s"', path)
         shutil.rmtree(path)
 
-    print('Copying assets into "{0}"'.format(path))
-    shutil.copytree(current_app.static_folder, path)
+    prefix = current_app.static_url_path or current_app.static_folder
+    if prefix.startswith('/'):
+        prefix = prefix[1:]
+    destination = join(path, prefix)
+    log.info('Copying application assets into "%s"', destination)
+    shutil.copytree(current_app.static_folder, destination)
+
+    for blueprint in current_app.blueprints.values():
+        if blueprint.has_static_folder:
+            prefix = current_app.static_prefixes.get(blueprint.name)
+            prefix = prefix or blueprint.url_prefix or ''
+            prefix += blueprint.static_url_path or ''
+            if prefix.startswith('/'):
+                prefix = prefix[1:]
+
+            log.info('Copying %s assets to %s', blueprint.name, prefix)
+            destination = join(path, prefix)
+            copy_recursive(blueprint.static_folder, destination)
 
     for prefix, source in manager.app.config['STATIC_DIRS']:
-        print('Copying %s to %s' % (source, prefix))
+        log.info('Copying %s to %s', source, prefix)
         destination = join(path, prefix)
         copy_recursive(source, destination)
 
-    print('Done')
+    log.info('Done')
 
 
 def copy_recursive(source, destination):
     if not exists(destination):
         makedirs(destination)
     for filename in iglob(join(source, '*')):
-        print(filename)
         if isdir(filename):
             suffix = filename.replace(source, '')
             if suffix.startswith(os.sep):


### PR DESCRIPTION
This PR improves and fixes the static collect command:
- ensure every file is copied into the right folder:
  - app static
  - blueprint static
  - theme static and STATIC_URLS
- uses the command logger instead of raw `print` statements
- stop being verbose for each copied file.