### PR TITLE
Hide deleted reuse on dataset page

### DIFF
--- a/udata/core/dataset/metrics.py
+++ b/udata/core/dataset/metrics.py
@@ -24,7 +24,7 @@ class DatasetReuses(Metric):
     display_name = _('Reuses')
 
     def get_value(self):
-        return Reuse.objects(datasets=self.target).count()
+        return Reuse.objects(datasets=self.target).visible().count()
 
 
 @Reuse.on_update.connect

--- a/udata/core/dataset/views.py
+++ b/udata/core/dataset/views.py
@@ -82,7 +82,7 @@ class DatasetDetailView(DatasetView, DetailView):
                 abort(404)
             elif self.dataset.deleted:
                 abort(410)
-        context['reuses'] = Reuse.objects(datasets=self.dataset)
+        context['reuses'] = Reuse.objects(datasets=self.dataset).visible()
         context['can_edit'] = DatasetEditPermission(self.dataset)
         context['can_edit_resource'] = CommunityResourceEditPermission
         context['discussions'] = DatasetDiscussion.objects(


### PR DESCRIPTION
This pull request ensure that private reuse, deleted and invalid reuse are neither dispayed on dataset page nor counted.