### PR TITLE
Added alternative Open License labelling handling

### DIFF
--- a/udata/harvest/backends/ods.py
+++ b/udata/harvest/backends/ods.py
@@ -22,6 +22,7 @@ class OdsHarvester(BaseBackend):
     LICENSES = {
         "Open Database License (ODbL)": "odc-odbl",
         "Licence Ouverte (Etalab)": "fr-lo",
+        "Licence ouverte / Open Licence": "fr-lo",
         "CC BY-SA": "cc-by-sa",
         "Public Domain": "other-pd"
     }


### PR DESCRIPTION
This is a temporary fix. It will be handled by mappings next (as both ODS and uData have dynamic licenses lists)