### PR TITLE
Expect an utf8-compatible terminal by default

### DIFF
--- a/udata/commands/__init__.py
+++ b/udata/commands/__init__.py
@@ -11,8 +11,11 @@ from glob import iglob
 from flask.ext.script import Manager
 from flask.ext.script.commands import Clean, ShowUrls, Server
 
-
 from udata.app import create_app, standalone
+
+# Expect an utf8 compatible terminal
+reload(sys)
+sys.setdefaultencoding('utf8')
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
This pull-request set the default output to utf-8 and fiix terminal output and encoding error when detection fail (ie. Jenkins)