### PR TITLE
using the organization acronym when available. fix #227

### DIFF
--- a/udata/core/organization/models.py
+++ b/udata/core/organization/models.py
@@ -134,11 +134,9 @@ class Organization(WithMetrics, BadgeMixin, db.Datetimed, db.Document):
     }
 
     def __str__(self):
-        return self.acronym or self.name or ''
+        return self.name or ''
 
     __unicode__ = __str__
-
-    __repr__ = __unicode__
 
     __badges__ = {
         PUBLIC_SERVICE: _('Public Service'),

--- a/udata/core/organization/models.py
+++ b/udata/core/organization/models.py
@@ -134,9 +134,11 @@ class Organization(WithMetrics, BadgeMixin, db.Datetimed, db.Document):
     }
 
     def __str__(self):
-        return self.name or ''
+        return self.acronym or self.name or ''
 
     __unicode__ = __str__
+
+    __repr__ = __unicode__
 
     __badges__ = {
         PUBLIC_SERVICE: _('Public Service'),

--- a/udata/templates/header.html
+++ b/udata/templates/header.html
@@ -52,7 +52,7 @@
               <a href="{{ url_for('organizations.show', org=org) }}">
                 <img src="{{ org.logo|placeholder('organization') }}"
                   width="20" height="20"/>
-                {{ org }}
+                {{ org.acronym or org.name }}
               </a>
             </li>
             {% endfor %}

--- a/udata/templates/header.html
+++ b/udata/templates/header.html
@@ -52,7 +52,7 @@
               <a href="{{ url_for('organizations.show', org=org) }}">
                 <img src="{{ org.logo|placeholder('organization') }}"
                   width="20" height="20"/>
-                {{ org.name }}
+                {{ org }}
               </a>
             </li>
             {% endfor %}


### PR DESCRIPTION
The theme should be modified accordingly.
See https://github.com/etalab/udata-gouvfr/compare/etalab:master...vinyll:227-use-organization-acronym