### PR TITLE
Harvest attach

### DIFF
--- a/udata/harvest/actions.py
+++ b/udata/harvest/actions.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
-import csv
 import logging
+import unicodecsv as csv
 
 from collections import namedtuple
 from datetime import datetime

--- a/udata/harvest/backends/ods.py
+++ b/udata/harvest/backends/ods.py
@@ -88,7 +88,7 @@ class OdsHarvester(BaseBackend):
         description = ods_metadata.get("description", '').strip()
         description = html2text.html2text(description.strip('\n').strip(),
                                           bodywidth=0)
-        dataset.description = description
+        dataset.description = description.strip().strip('\n').strip()
         dataset.private = False
 
         tags = set()

--- a/udata/harvest/backends/ods.py
+++ b/udata/harvest/backends/ods.py
@@ -86,8 +86,9 @@ class OdsHarvester(BaseBackend):
         dataset.title = ods_metadata['title']
         dataset.frequency = "unknown"
         description = ods_metadata.get("description", '').strip()
-        description = html2text.html2text(description.strip('\n').strip())
-        dataset.description = html2text.html2text(description).strip('\n')
+        description = html2text.html2text(description.strip('\n').strip(),
+                                          bodywidth=0)
+        dataset.description = description
         dataset.private = False
 
         tags = set()

--- a/udata/harvest/commands.py
+++ b/udata/harvest/commands.py
@@ -125,3 +125,12 @@ def purge():
     log.info('Purging deleted harvest sources')
     count = actions.purge_sources()
     log.info('Purged %s source(s)', count)
+
+
+@m.option('filename', help='The mapping CSV filename')
+@m.option('domain', help='The remote domain')
+def attach(domain, filename):
+    '''Attach existing dataset to their harvest remote id.'''
+    log.info('Attaching datasets for domain %s', domain)
+    count = actions.attach(domain, filename)
+    log.info('Attached %s datasets to %s', count, domain)

--- a/udata/harvest/commands.py
+++ b/udata/harvest/commands.py
@@ -132,5 +132,5 @@ def purge():
 def attach(domain, filename):
     '''Attach existing dataset to their harvest remote id.'''
     log.info('Attaching datasets for domain %s', domain)
-    count = actions.attach(domain, filename)
-    log.info('Attached %s datasets to %s', count, domain)
+    result = actions.attach(domain, filename)
+    log.info('Attached %s datasets to %s', result.success, domain)

--- a/udata/harvest/tests/test_actions.py
+++ b/udata/harvest/tests/test_actions.py
@@ -241,9 +241,10 @@ class HarvestActionsTest(DBTestMixin, TestCase):
                 })
             csvfile.flush()
 
-            count = actions.attach('test.org', csvfile.name)
+            result = actions.attach('test.org', csvfile.name)
 
-        self.assertEqual(count, len(datasets))
+        self.assertEqual(result.success, len(datasets))
+        self.assertEqual(result.errors, 0)
         for index, dataset in enumerate(datasets):
             dataset.reload()
             self.assertEqual(dataset.extras['harvest:domain'], 'test.org')
@@ -274,13 +275,13 @@ class HarvestActionsTest(DBTestMixin, TestCase):
                 })
             csvfile.flush()
 
-            count = actions.attach('test.org', csvfile.name)
+            result = actions.attach('test.org', csvfile.name)
 
         dbcount = Dataset.objects(**{
             'extras__harvest:remote_id__exists': True
             }).count()
-        self.assertEqual(count, len(datasets))
-        self.assertEqual(dbcount, count)
+        self.assertEqual(result.success, len(datasets))
+        self.assertEqual(dbcount, result.success)
         for index, dataset in enumerate(datasets):
             dataset.reload()
             self.assertEqual(dataset.extras['harvest:domain'], 'test.org')
@@ -307,9 +308,10 @@ class HarvestActionsTest(DBTestMixin, TestCase):
                 })
             csvfile.flush()
 
-            count = actions.attach('test.org', csvfile.name)
+            result = actions.attach('test.org', csvfile.name)
 
-        self.assertEqual(count, len(datasets))
+        self.assertEqual(result.success, len(datasets))
+        self.assertEqual(result.errors, 1)
 
 
 class ExecutionTestMixin(DBTestMixin):

--- a/udata/harvest/tests/test_actions.py
+++ b/udata/harvest/tests/test_actions.py
@@ -1,16 +1,20 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+import csv
 import logging
 
 from datetime import datetime
+from tempfile import NamedTemporaryFile
 
 from mock import patch
 
 from udata.models import Dataset, PeriodicTask
 
 from udata.tests import TestCase, DBTestMixin
-from udata.tests.factories import OrganizationFactory, UserFactory
+from udata.tests.factories import (
+    OrganizationFactory, UserFactory, DatasetFactory
+)
 
 from .factories import (
     fake, HarvestSourceFactory, HarvestJobFactory,
@@ -219,6 +223,93 @@ class HarvestActionsTest(DBTestMixin, TestCase):
 
         self.assertEqual(result, len(to_delete))
         self.assertEqual(len(HarvestSource.objects), len(to_keep))
+
+    def test_attach(self):
+        datasets = DatasetFactory.create_batch(3)
+
+        with NamedTemporaryFile() as csvfile:
+            writer = csv.DictWriter(csvfile,
+                                    fieldnames=['local', 'remote'],
+                                    delimiter=b';',
+                                    quotechar=b'"')
+
+            writer.writeheader()
+            for index, dataset in enumerate(datasets):
+                writer.writerow({
+                    'local': str(dataset.id),
+                    'remote': str(index)
+                })
+            csvfile.flush()
+
+            count = actions.attach('test.org', csvfile.name)
+
+        self.assertEqual(count, len(datasets))
+        for index, dataset in enumerate(datasets):
+            dataset.reload()
+            self.assertEqual(dataset.extras['harvest:domain'], 'test.org')
+            self.assertEqual(dataset.extras['harvest:remote_id'], str(index))
+
+    def test_attach_does_not_duplicate(self):
+        attached_datasets = []
+        for i in range(2):
+            dataset = DatasetFactory.build()
+            dataset.extras['harvest:domain'] = 'test.org'
+            dataset.extras['harvest:remote_id'] = str(i)
+            dataset.save()
+            attached_datasets.append(dataset)
+
+        datasets = DatasetFactory.create_batch(3)
+
+        with NamedTemporaryFile() as csvfile:
+            writer = csv.DictWriter(csvfile,
+                                    fieldnames=['local', 'remote'],
+                                    delimiter=b';',
+                                    quotechar=b'"')
+
+            writer.writeheader()
+            for index, dataset in enumerate(datasets):
+                writer.writerow({
+                    'local': str(dataset.id),
+                    'remote': str(index)
+                })
+            csvfile.flush()
+
+            count = actions.attach('test.org', csvfile.name)
+
+        dbcount = Dataset.objects(**{
+            'extras__harvest:remote_id__exists': True
+            }).count()
+        self.assertEqual(count, len(datasets))
+        self.assertEqual(dbcount, count)
+        for index, dataset in enumerate(datasets):
+            dataset.reload()
+            self.assertEqual(dataset.extras['harvest:domain'], 'test.org')
+            self.assertEqual(dataset.extras['harvest:remote_id'], str(index))
+
+    def test_attach_skip_not_found(self):
+        datasets = DatasetFactory.create_batch(3)
+
+        with NamedTemporaryFile() as csvfile:
+            writer = csv.DictWriter(csvfile,
+                                    fieldnames=['local', 'remote'],
+                                    delimiter=b';',
+                                    quotechar=b'"')
+
+            writer.writeheader()
+            writer.writerow({
+                'local': 'not-found',
+                'remote': '42'
+            })
+            for index, dataset in enumerate(datasets):
+                writer.writerow({
+                    'local': str(dataset.id),
+                    'remote': str(index)
+                })
+            csvfile.flush()
+
+            count = actions.attach('test.org', csvfile.name)
+
+        self.assertEqual(count, len(datasets))
 
 
 class ExecutionTestMixin(DBTestMixin):


### PR DESCRIPTION
This pull-request add the `udata harvest attach` command allowing to link existing datasets to their remote ID from a CSV before harvest.

It also fixes the ODS backend HTML to Markdown conversion