### PR TITLE
replacing marked.js with commonmark. fix #253

### DIFF
--- a/js/apidoc.js
+++ b/js/apidoc.js
@@ -16,7 +16,6 @@ require('swaggerui/lib/jquery.wiggle.min');
 require('script!swaggerui/lib/jquery.ba-bbq.min');
 
 require('expose?Handlebars!handlebars');
-require('expose?marked!marked');
 require('script!swaggerui/lib/underscore-min');
 require('script!swaggerui/lib/backbone-min');
 

--- a/js/components/form/markdown-editor.vue
+++ b/js/components/form/markdown-editor.vue
@@ -52,10 +52,10 @@
 import $ from 'jquery';
 import Vue from 'vue';
 import {FieldComponentMixin} from 'components/form/base-field';
+import commonmark from 'helpers/commonmark';
 
 const EXCERPT_TOKEN = '<!--- excerpt -->';
 
-window.marked = require('marked');
 require('bootstrap-markdown/js/bootstrap-markdown');
 
 $.fn.markdown.messages[Vue.lang] = {
@@ -89,6 +89,7 @@ export default {
             savable: false,
             resize: 'both',
             iconlibrary: 'fa',
+            onPreview: (e) => commonmark(e.getContent()),
             additionalButtons: [
                 [{
                     name: 'extras',

--- a/js/form/markdown.js
+++ b/js/form/markdown.js
@@ -4,14 +4,12 @@
 define([
     'jquery',
     'i18n',
-    'marked',
+    'helpers/commonmark',
     'bootstrap-markdown/js/bootstrap-markdown'
-], function($, i18n, md) {
+], function($, i18n, commonmark) {
     'use strict';
 
     var EXCERPT_TOKEN = '<!--- excerpt -->';
-
-    window.marked = md;
 
     $.fn.markdown.messages[i18n.lang] = {
         'Bold': i18n._('Bold'),
@@ -39,6 +37,7 @@ define([
         savable: false,
         resize: 'both',
         iconlibrary: 'fa',
+        onPreview: (e) => commonmark(e.getContent()),
         additionalButtons: [
             [{
                 name: 'extras',

--- a/js/helpers/commonmark.js
+++ b/js/helpers/commonmark.js
@@ -1,0 +1,9 @@
+import markdownit from 'markdown-it';
+import { options } from 'markdown-it/lib/presets/commonmark';
+
+
+export default function(text) {
+    options.linkify = true;
+    let markdown = markdownit(options);
+    return markdown.render(text);
+};

--- a/js/plugins/markdown.js
+++ b/js/plugins/markdown.js
@@ -1,4 +1,4 @@
-define(['jquery', 'marked', 'helpers/text'], function($, marked, txt) {
+define(['jquery', 'helpers/commonmark', 'helpers/text'], function($, commonmark, txt) {
     'use strict';
 
     return function(Vue, options) {
@@ -9,7 +9,7 @@ define(['jquery', 'marked', 'helpers/text'], function($, marked, txt) {
                 $(this.el).addClass('markdown');
             },
             update: function(value) {
-                this.el.innerHTML = value ? marked(value) : '';
+                this.el.innerHTML = value ? commonmark(value) : '';
             },
             unbind: function() {
                 $(this.el).removeClass('markdown');
@@ -22,13 +22,11 @@ define(['jquery', 'marked', 'helpers/text'], function($, marked, txt) {
             }
             if (max_length) {
                 var div = document.createElement("div");
-                div.innerHTML = marked(text);
+                div.innerHTML = commonmark(text);
                 return txt.truncate(div.textContent || div.innerText || '', max_length);
             } else {
-                return marked(text);
+                return commonmark(text);
             }
         });
     };
 });
-
-

--- a/js/templates/helpers/md.js
+++ b/js/templates/helpers/md.js
@@ -1,7 +1,7 @@
-define(['handlebars', 'marked'], function(Handlebars, marked) {
+define(['handlebars', 'helpers/commonmark'], function(Handlebars, commonmark) {
 
     return function(value) {
-        return new Handlebars.SafeString(marked(value));
+        return new Handlebars.SafeString(commonmark(value));
     };
 
 });

--- a/js/templates/helpers/mdshort.js
+++ b/js/templates/helpers/mdshort.js
@@ -1,4 +1,4 @@
-define(['handlebars', 'marked'], function(Handlebars, marked) {
+define(['handlebars', 'helpers/commonmark'], function(Handlebars, commonmark) {
 
     var EXCERPT_TOKEN = '<!--- --- -->',
         DEFAULT_LENGTH = 128;
@@ -13,7 +13,7 @@ define(['handlebars', 'marked'], function(Handlebars, marked) {
             value = value.split(EXCERPT_TOKEN, 1)[0];
         }
         ellipsis = value.length >= length ? '...' : '';
-        text = marked(value.substring(0, length) + ellipsis);
+        text = commonmark(value.substring(0, length) + ellipsis);
         text = text.replace('<a ', '<span ').replace('</a>', '</span>');
         return new Handlebars.SafeString(text);
     };

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "webpack": "1.12.2"
   },
   "dependencies": {
+    "Chart.StackedBar.js": "regaddi/Chart.StackedBar.js#1.0.3",
     "admin-lte": "^2.3.0",
     "babel-runtime": "^5.6.25",
     "backbone": "^1.2.0",
@@ -66,7 +67,6 @@
     "bootstrap-markdown": "^2.9.0",
     "bootstrap-slider": "~5.2.3",
     "chart.js": "^1.0.2",
-    "Chart.StackedBar.js": "regaddi/Chart.StackedBar.js#1.0.3",
     "debounce": "^1.0.0",
     "dotdotdot": "BeSite/jQuery.dotdotdot#v1.7.4",
     "expose-loader": "^0.7.0",
@@ -83,7 +83,7 @@
     "jquery-validation-dist": "^1.13.2-pre",
     "jquery.browser": "0.0.8",
     "leaflet": "^0.7.5",
-    "marked": "^0.3.5",
+    "markdown-it": "^5.0.1",
     "moment": "^2.10.6",
     "raven-js": "^1.1.22",
     "respond.js": "^1.4.2",


### PR DESCRIPTION
fixing #253 
- Replaced marked with [markdown-it](https://github.com/markdown-it/markdown-it) which is commonmark compliant
- created a preconfigured and easy to call module (helpers/commonmark.js)