### PR TITLE
Ensure CommunityResources have an UUID as primary key

### DIFF
--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -109,6 +109,7 @@ class Checksum(db.EmbeddedDocument):
 
 
 class ResourceMixin(object):
+    id = db.AutoUUIDField(primary_key=True)
     title = db.StringField(verbose_name="Title", required=True)
     description = db.StringField()
     filetype = db.StringField(
@@ -156,8 +157,6 @@ class ResourceMixin(object):
 
 
 class Resource(ResourceMixin, WithMetrics, db.EmbeddedDocument):
-    id = db.AutoUUIDField()
-
     on_added = signal('Resource.on_added')
     on_deleted = signal('Resource.on_deleted')
 

--- a/udata/migrations/2015-11-23-set-uuid-as-community-resources-id.js
+++ b/udata/migrations/2015-11-23-set-uuid-as-community-resources-id.js
@@ -1,0 +1,29 @@
+/*
+ * Ensure all community resources have an UUID string as ID
+ */
+
+/**
+ * Generate a rfc4122 version 4 UUID
+ */
+function uuid() {
+    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+        var r = Math.random()*16|0, v = c == 'x' ? r : (r&0x3|0x8);
+        return v.toString(16);
+    });
+}
+
+
+var resources = db.community_resource.find(),
+    count = 0;
+
+resources.forEach(function(resource) {
+    try {
+        UUID(resource._id.replace(/-/g, ''));
+    } catch (e) {
+        resource._id = uuid();
+        db.community_resources.save(resource);
+        count++;
+    }
+});
+
+print('Migrated '+count+' community resource(s)');

--- a/udata/routing.py
+++ b/udata/routing.py
@@ -70,7 +70,7 @@ class ModelConverter(BaseConverter):
             return e
 
     def to_url(self, obj):
-        if isinstance(obj, (basestring, ObjectId)):
+        if isinstance(obj, (basestring, ObjectId, UUID)):
             return str(obj)
         elif getattr(obj, 'slug', None):
             return obj.slug

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -818,6 +818,17 @@ class CommunityResourceAPITest(APITestCase):
         data = json.loads(response.data)
         self.assertEqual(data['id'], str(community_resource.id))
 
+    def test_community_resource_api_get_from_string_id(self):
+        '''It should fetch a community resource from the API'''
+        with self.autoindex():
+            community_resource = CommunityResourceFactory()
+
+        response = self.get(url_for('api.community_resource',
+                                    community=str(community_resource.id)))
+        self.assert200(response)
+        data = json.loads(response.data)
+        self.assertEqual(data['id'], str(community_resource.id))
+
     def test_community_resource_api_create(self):
         '''It should create a community resource from the API'''
         self.login()

--- a/udata/tests/test_model.py
+++ b/udata/tests/test_model.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 from flask import json
 
-from uuid import uuid4
+from uuid import uuid4, UUID
 from datetime import date, datetime, timedelta
 
 from mongoengine.errors import ValidationError
@@ -14,6 +14,10 @@ from udata.tests import TestCase, DBTestMixin
 
 class UUIDTester(db.Document):
     uuid = db.AutoUUIDField()
+
+
+class UUIDAsIdTester(db.Document):
+    id = db.AutoUUIDField(primary_key=True)
 
 
 class SlugTester(db.Document):
@@ -50,12 +54,19 @@ class AutoUUIDFieldTest(TestCase):
         '''AutoUUIDField should populate itself if not set'''
         obj = UUIDTester()
         self.assertIsNotNone(obj.uuid)
+        self.assertIsInstance(obj.uuid, UUID)
 
     def test_do_not_overwrite(self):
         '''AutoUUIDField shouldn't populate itself if a value is already set'''
         uuid = uuid4()
         obj = UUIDTester(uuid=uuid)
         self.assertEqual(obj.uuid, uuid)
+
+    def test_as_primary_key(self):
+        obj = UUIDAsIdTester()
+        self.assertIsNotNone(obj.id)
+        self.assertIsInstance(obj.id, UUID)
+        self.assertEqual(obj.pk, obj.id)
 
 
 class SlugFieldTest(DBTestMixin, TestCase):


### PR DESCRIPTION
This PR ensure community resources have an UUID as primary key and routing on UUID is correct.