### PR TITLE
fixed dataset with empty spatial coverage

### DIFF
--- a/udata/templates/dataset/display.html
+++ b/udata/templates/dataset/display.html
@@ -347,7 +347,7 @@
                 </div>
 
                 {# Geospatial panel #}
-                {% if dataset.spatial %}
+                {% if dataset.spatial.geom or dataset.spatial.zones %}
                 <div class="panel panel-default">
                     <div class="panel-body">
                         <h3>{{ _('Spatial coverage') }}</h3>


### PR DESCRIPTION
Before:
![empty spatial coverage](https://trello-attachments.s3.amazonaws.com/566ad4ceb90abade7dba65d3/384x272/24c7ecb407fa9b987abb146b15cc4768/Screen_Shot_2015-12-11_at_2.52.18_PM.png)

After: the empty block is removed