### PR TITLE
Docker composer volumes path to relative

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ db:
     image: mongo:2.6
     command: mongod
     volumes:
-      - data/db:/data/db
+      - ./data/db:/data/db
     expose:
       - "27017"
     ports:
@@ -11,7 +11,7 @@ db:
 broker:
     image: redis
     volumes:
-      - data/broker:/data
+      - ./data/broker:/data
     expose:
       - "6379"
     ports:
@@ -20,8 +20,8 @@ broker:
 search:
     image: elasticsearch:1.4
     volumes:
-      - data/search/data:/usr/share/elasticsearch/data
-      - data/search/plugins:/usr/share/elasticsearch/plugins
+      - ./data/search/data:/usr/share/elasticsearch/data
+      - ./data/search/plugins:/usr/share/elasticsearch/plugins
       # - ./logs:/data/log
     expose:
       - "9200"


### PR DESCRIPTION
`docker-compose up` raises these errors on OSX:

    ERROR: data/search/plugins includes invalid characters for a local volume name, only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed
    ...
    ERROR: data/db includes invalid characters for a local volume name, only [a-zA-Z0-9][a-zA-Z0-9_.-] are allowed