### PR TITLE
Fix the missing JSONeditor dependency from the last swagger ui update

### DIFF
--- a/js/apidoc.js
+++ b/js/apidoc.js
@@ -17,6 +17,7 @@ import 'script!swaggerui/lib/jquery.ba-bbq.min';
 import 'expose?Handlebars!handlebars';
 import 'script!swaggerui/lib/underscore-min';
 import 'script!swaggerui/lib/backbone-min';
+import 'script!swaggerui/lib/jsoneditor-min';
 
 import 'script!swaggerui/swagger-ui.min';
 SwaggerUi = window.SwaggerUi;
@@ -46,6 +47,7 @@ $(function() {
             log.error('Unable to Load SwaggerUI');
         },
         docExpansion: 'none',
+        jsonEditor:true,
         sorter: 'alpha'
     });
 


### PR DESCRIPTION
This fix the admin doc view which is broken due to a new SwaggerUI dependency missing (JSONeditor).
Even if the feature is optionnal, the dependency is required so I also activated it.