### PR TITLE
added send_mail setting for environment control

### DIFF
--- a/doc/configuration.rst
+++ b/doc/configuration.rst
@@ -32,6 +32,8 @@ Here a sample configuration file:
     ASSETS_AUTO_BUILD = True
     # REQUIREJS_RUN_IN_DEBUG = True
 
+    SEND_MAIL = False
+
     SECRET_KEY = 'A unique secret key'
 
     USE_SSL = True
@@ -66,6 +68,13 @@ DEBUG
 **default**: ``False``
 
 A boolean specifying the debug mode.
+
+SEND_MAIL
+*********
+
+**default**: ``True``
+
+A boolean specifying if the emails should actually be sent.
 
 USE_SSL
 *******

--- a/udata/mail.py
+++ b/udata/mail.py
@@ -37,7 +37,8 @@ def send(subject, recipients, template_base, **kwargs):
         recipients = [recipients]
 
     debug = current_app.config.get('DEBUG')
-    connection = debug and dummyconnection or mail.connect
+    send_mail = current_app.config.get('SEND_MAIL', not debug)
+    connection = send_mail and dummyconnection or mail.connect
 
     with connection() as conn:
         for recipient in recipients:

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals
 class Defaults(object):
     DEBUG = False
     TESTING = False
+    SEND_MAIL = True
     LANGUAGES = {
         'en': 'English',
         'fr': 'Français',
@@ -114,8 +115,9 @@ class Defaults(object):
 
 
 class Testing(object):
-    '''Sane values for testing. Should be applied as ovveride'''
+    '''Sane values for testing. Should be applied as override'''
     TESTING = True
+    SEND_MAIL = False
     WTF_CSRF_ENABLED = False
     AUTO_INDEX = False
     CELERY_ALWAYS_EAGER = True
@@ -132,6 +134,7 @@ class Testing(object):
 
 class Debug(Defaults):
     DEBUG = True
+    SEND_MAIL = False
     DEBUG_TB_INTERCEPT_REDIRECTS = False
     DEBUG_TB_PANELS = (
         'flask.ext.debugtoolbar.panels.versions.VersionDebugPanel',


### PR DESCRIPTION
Added a `SEND_MAIL` settings.
This should be set for the _next_ server to `False` so emails are not actually sent.