### PR TITLE
Use babel transform-runtime plugin for all project  JS files

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,5 @@
+{
+    "presets": ["es2015"],
+    "plugins": ["transform-runtime"],
+    "comments": false
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,6 @@ const node_path = path.join(__dirname, 'node_modules');
 
 const css_loader = ExtractTextPlugin.extract('style', 'css?sourceMap');
 const less_loader = ExtractTextPlugin.extract('style', 'css?sourceMap!less?sourceMap=source-map-less-inline');
-const js_loader = 'babel?presets[]=es2015&plugins[]=transform-runtime';
 const handlebars_helpers = path.join(__dirname, 'js', 'templates', 'helpers');
 const hbs_loader = `handlebars?helperDirs[]=${handlebars_helpers}`;
 
@@ -60,7 +59,7 @@ module.exports = {
             {test: /\.json$/, loader: 'json'},
             {test: /\.hbs$/, loader: hbs_loader},
             {test: /\.(woff|svg|ttf|eot|otf)([\?]?.*)$/, loader: 'file-loader?name=[name].[ext]'},
-            {test: /\.js$/, exclude: /node_modules/, loader: js_loader},
+            {test: /\.js$/, exclude: /node_modules/, loader: 'babel'},
         ]
     },
     vue: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,7 @@ const node_path = path.join(__dirname, 'node_modules');
 
 const css_loader = ExtractTextPlugin.extract('style', 'css?sourceMap');
 const less_loader = ExtractTextPlugin.extract('style', 'css?sourceMap!less?sourceMap=source-map-less-inline');
-const js_loader = 'babel?presets[]=es2015';
+const js_loader = 'babel?presets[]=es2015&plugins[]=transform-runtime';
 const handlebars_helpers = path.join(__dirname, 'js', 'templates', 'helpers');
 const hbs_loader = `handlebars?helperDirs[]=${handlebars_helpers}`;
 


### PR DESCRIPTION
Add transform-runtime plugin everywhere.

NB: babel configuration can also be specified in `package.json` or `.babelrc`, which one do you prefer ?