### PR TITLE
Ensure checksum type is always present

### DIFF
--- a/udata/core/dataset/api.py
+++ b/udata/core/dataset/api.py
@@ -252,7 +252,7 @@ class UploadMixin(object):
         return {
             'title': os.path.basename(filename),
             'url': storage.url(filename, external=True),
-            'checksum': Checksum(value=sha1),
+            'checksum': Checksum(type='sha1', value=sha1),
             'format': extension,
             'mime': storages.utils.mime(filename),
             'filesize': filesize

--- a/udata/core/dataset/forms.py
+++ b/udata/core/dataset/forms.py
@@ -22,27 +22,6 @@ class ChecksumForm(ModelForm):
     value = fields.StringField()
 
 
-class ChecksumWidget(object):
-    def __call__(self, field, **kwargs):
-        html = [
-            '<div class="input-group checksum-group">',
-            '<div class="input-group-btn">',
-            field.form.type(class_='btn btn-default'),
-            '</div>',
-            field.value(class_='form-control'),
-            '</div>'
-        ]
-        return widgets.HTMLString(''.join(html))
-
-
-class ChecksumField(fields.FormField):
-    widget = ChecksumWidget()
-
-    def __init__(self, label=None, validators=None, **kwargs):
-        super(ChecksumField, self).__init__(ChecksumForm, label, validators,
-                                            **kwargs)
-
-
 class BaseResourceForm(ModelForm):
     title = fields.StringField(_('Title'), [validators.required()])
     description = fields.MarkdownField(_('Description'))
@@ -55,7 +34,7 @@ class BaseResourceForm(ModelForm):
         _('URL'), [validators.required()], storage=resources)
     format = fields.StringField(
         _('Format'), widget=widgets.FormatAutocompleter())
-    checksum = ChecksumField(_('Checksum'))
+    checksum = fields.FormField(ChecksumForm)
     mime = fields.StringField(
         _('Mime type'),
         description=_('The mime type associated to the extension. '

--- a/udata/core/dataset/models.py
+++ b/udata/core/dataset/models.py
@@ -94,8 +94,8 @@ class DatasetQuerySet(OwnedByQuerySet):
 
 
 class Checksum(db.EmbeddedDocument):
-    type = db.StringField(choices=CHECKSUM_TYPES)
-    value = db.StringField()
+    type = db.StringField(choices=CHECKSUM_TYPES, required=True)
+    value = db.StringField(required=True)
 
     def to_mongo(self, *args, **kwargs):
         if bool(self.value):
@@ -383,6 +383,7 @@ class Dataset(WithMetrics, BadgeMixin, db.Datetimed, db.Document):
 
     def add_resource(self, resource):
         '''Perform an atomic prepend for a new resource'''
+        resource.validate()
         self.update(__raw__={
             '$push': {
                 'resources': {

--- a/udata/core/spatial/tests/test_fields.py
+++ b/udata/core/spatial/tests/test_fields.py
@@ -41,7 +41,7 @@ class SpatialCoverageFieldTest(TestCase):
 
         fake = Fake()
         form.populate_obj(fake)
-        self.assertIsInstance(fake.spatial, SpatialCoverage)
+        self.assertIsNone(fake.spatial)
 
     def test_initial_geom(self):
         Fake, FakeForm = self.factory()

--- a/udata/forms/fields.py
+++ b/udata/forms/fields.py
@@ -198,9 +198,10 @@ class FormWrapper(object):
 
 class FormField(FieldHelper, fields.FormField):
     def __init__(self, form_class, *args, **kwargs):
-        self.has_data = False
         super(FormField, self).__init__(FormWrapper(form_class),
                                         *args, **kwargs)
+        self.prefix = '{0}-'.format(self.name)
+        self.has_data = False
 
     def process(self, formdata, data=unset_value):
         self._formdata = formdata
@@ -209,11 +210,11 @@ class FormField(FieldHelper, fields.FormField):
     def validate(self, form, extra_validators=tuple()):
         if extra_validators:
             raise TypeError('FormField does not accept in-line validators, '
-            'as it gets errors from the enclosed form.')
+                            'as it gets errors from the enclosed form.')
 
         # Run normal validation only if there is data for this form
-        prefix = '{0}-'.format(self.name)
-        self.has_data = self._formdata and any(k.startswith(prefix) for k in self._formdata)
+        self.has_data = bool(self._formdata)
+        self.has_data &= any(k.startswith(self.prefix) for k in self._formdata)
         if self.has_data:
             return self.form.validate()
         return True

--- a/udata/forms/fields.py
+++ b/udata/forms/fields.py
@@ -23,9 +23,7 @@ from udata.core.organization.permissions import OrganizationPrivatePermission
 from udata.i18n import lazy_gettext as _
 from udata.utils import to_iso_date, get_by
 
-
 # _ = lambda s: s
-
 
 RE_TAG = re.compile('^[\w \-.]*$', re.U)
 MIN_TAG_LENGTH = 2
@@ -200,10 +198,29 @@ class FormWrapper(object):
 
 class FormField(FieldHelper, fields.FormField):
     def __init__(self, form_class, *args, **kwargs):
+        self.has_data = False
         super(FormField, self).__init__(FormWrapper(form_class),
                                         *args, **kwargs)
 
+    def process(self, formdata, data=unset_value):
+        self._formdata = formdata
+        return super(FormField, self).process(formdata, data=data)
+
+    def validate(self, form, extra_validators=tuple()):
+        if extra_validators:
+            raise TypeError('FormField does not accept in-line validators, '
+            'as it gets errors from the enclosed form.')
+
+        # Run normal validation only if there is data for this form
+        prefix = '{0}-'.format(self.name)
+        self.has_data = self._formdata and any(k.startswith(prefix) for k in self._formdata)
+        if self.has_data:
+            return self.form.validate()
+        return True
+
     def populate_obj(self, obj, name):
+        if not self.has_data:
+            return
         if getattr(self.form_class, 'model_class', None) and not self._obj:
             self._obj = self.form_class.model_class()
         super(FormField, self).populate_obj(obj, name)
@@ -391,16 +408,29 @@ class NestedModelList(fields.FieldList):
         self.nested_model = model_form.model_class
         self.data_submitted = False
         self.initial_data = []
+        self.prefix = '{0}-'.format(self.name)
 
     def process(self, formdata, data=unset_value):
+        self._formdata = formdata
         self.initial_data = data
-        prefix = '{0}-'.format(self.name)
-        if formdata and any(k.startswith(prefix) for k in formdata):
+        self.has_data = formdata and any(k.startswith(self.prefix) for k in formdata)
+        if self.has_data:
             super(NestedModelList, self).process(formdata, data)
         else:
-            super(NestedModelList, self).process(None, data)
+            self.entries = []
+            # super(NestedModelList, self).process(None, data)
+
+    def validate(self, form, extra_validators=tuple()):
+        '''Perform validation only if data has been submitted'''
+        # Run normal validation only if there is data for this form
+        if self.has_data:
+            return super(NestedModelList, self).validate(form, extra_validators)
+        return True
 
     def populate_obj(self, obj, name):
+        if not self.has_data:
+            return
+
         new_values = []
 
         class Holder(object):
@@ -417,7 +447,7 @@ class NestedModelList(fields.FieldList):
 
     def _add_entry(self, formdata=None, data=unset_value, index=None):
         '''
-        Fill the form with previous data if necessary to handle partiel update
+        Fill the form with previous data if necessary to handle partial update
         '''
         if formdata:
             prefix = '-'.join((self.name, str(index)))

--- a/udata/migrations/2016-01-25-fix-resources-checksums.js
+++ b/udata/migrations/2016-01-25-fix-resources-checksums.js
@@ -1,0 +1,28 @@
+/*
+ * Ensure all resources with checksum have a checksum type
+ */
+
+var datasets = db.dataset.find({
+    'resources.checksum.value': {$exists: true},
+    'resources.checksum.type': {$exists: false}
+});
+
+print('Candidates: ' + datasets.count());
+
+var counter = 0;
+var count = 0;
+
+datasets.forEach(function(dataset) {
+    var resources = dataset.resources.map(function(resource) {
+        if (resource.checksum && resource.checksum.value && !resource.checksum.type) {
+            resource.checksum.type = 'sha1';
+            count++;
+        }
+        return resource;
+    });
+    var result = db.dataset.update({_id: dataset._id},
+                                   {$set: {resources: resources}});
+    counter += result.nModified;
+});
+print(count, 'resources modified.');
+print(counter, 'datasets modified.');

--- a/udata/tests/__init__.py
+++ b/udata/tests/__init__.py
@@ -176,6 +176,7 @@ class SearchTestMixin(DBTestMixin):
         self._used_search = True
         self.app.config['AUTO_INDEX'] = True
         es.initialize()
+        es.cluster.health(wait_for_status='yellow', request_timeout=3)
 
     @contextmanager
     def autoindex(self):

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -20,6 +20,9 @@ from ..factories import (
     AdminFactory, UserFactory, LicenseFactory
 )
 
+from nose.plugins.attrib import attr
+
+
 SAMPLE_GEOM = {
     "type": "MultiPolygon",
     "coordinates": [
@@ -93,6 +96,7 @@ class DatasetAPITest(APITestCase):
         response = self.get(url_for('api.dataset', dataset=dataset))
         self.assert200(response)
 
+    @attr('create')
     def test_dataset_api_create(self):
         '''It should create a dataset from the API'''
         data = DatasetFactory.attributes()
@@ -105,6 +109,7 @@ class DatasetAPITest(APITestCase):
         self.assertEqual(dataset.owner, self.user)
         self.assertIsNone(dataset.organization)
 
+    @attr('create')
     def test_dataset_api_create_as_org(self):
         '''It should create a dataset as organization from the API'''
         self.login()
@@ -121,6 +126,7 @@ class DatasetAPITest(APITestCase):
         self.assertEqual(dataset.organization, org)
         self.assertIsNone(dataset.owner)
 
+    @attr('create')
     def test_dataset_api_create_as_org_permissions(self):
         """It should create a dataset as organization from the API
 
@@ -134,6 +140,7 @@ class DatasetAPITest(APITestCase):
         self.assert400(response)
         self.assertEqual(Dataset.objects.count(), 0)
 
+    @attr('create')
     def test_dataset_api_create_tags(self):
         '''It should create a dataset from the API'''
         data = DatasetFactory.attributes()
@@ -145,6 +152,7 @@ class DatasetAPITest(APITestCase):
         dataset = Dataset.objects.first()
         self.assertEqual(dataset.tags, data['tags'])
 
+    @attr('create')
     def test_dataset_api_create_with_extras(self):
         '''It should create a dataset with extras from the API'''
         data = DatasetFactory.attributes()
@@ -163,6 +171,7 @@ class DatasetAPITest(APITestCase):
         self.assertEqual(dataset.extras['float'], 42.0)
         self.assertEqual(dataset.extras['string'], 'value')
 
+    @attr('create')
     def test_dataset_api_create_with_resources(self):
         '''It should create a dataset with resources from the API'''
         data = DatasetFactory.attributes()
@@ -176,6 +185,7 @@ class DatasetAPITest(APITestCase):
         dataset = Dataset.objects.first()
         self.assertEqual(len(dataset.resources), 3)
 
+    @attr('create')
     def test_dataset_api_create_with_geom(self):
         '''It should create a dataset with resources from the API'''
         data = DatasetFactory.attributes()
@@ -204,6 +214,7 @@ class DatasetAPITest(APITestCase):
             'description_length': 42
         })
 
+    @attr('update')
     def test_dataset_api_update(self):
         '''It should update a dataset from the API'''
         user = self.login()
@@ -216,6 +227,7 @@ class DatasetAPITest(APITestCase):
         self.assertEqual(Dataset.objects.first().description,
                          'new description')
 
+    @attr('update')
     def test_dataset_api_update_with_resources(self):
         '''It should update a dataset from the API with resources parameters'''
         user = self.login()
@@ -230,6 +242,7 @@ class DatasetAPITest(APITestCase):
         dataset = Dataset.objects.first()
         self.assertEqual(len(dataset.resources), initial_length + 1)
 
+    @attr('update')
     def test_dataset_api_update_without_resources(self):
         '''It should update a dataset from the API without resources'''
         user = self.login()
@@ -247,6 +260,7 @@ class DatasetAPITest(APITestCase):
         self.assertEqual(dataset.description, data['description'])
         self.assertEqual(len(dataset.resources), initial_length)
 
+    @attr('update')
     def test_dataset_api_update_with_extras(self):
         '''It should update a dataset from the API with extras parameters'''
         user = self.login()
@@ -266,6 +280,7 @@ class DatasetAPITest(APITestCase):
         self.assertEqual(dataset.extras['float'], 42.0)
         self.assertEqual(dataset.extras['string'], 'value')
 
+    @attr('update')
     def test_dataset_api_update_with_no_extras(self):
         '''It should update a dataset from the API with no extras
 
@@ -292,6 +307,7 @@ class DatasetAPITest(APITestCase):
         self.assertEqual(dataset.extras['float'], 42.0)
         self.assertEqual(dataset.extras['string'], 'value')
 
+    @attr('update')
     def test_dataset_api_update_with_empty_extras(self):
         '''It should update a dataset from the API with empty extras
 
@@ -316,6 +332,7 @@ class DatasetAPITest(APITestCase):
         dataset = Dataset.objects.first()
         self.assertEqual(dataset.extras, {})
 
+    @attr('update')
     def test_dataset_api_update_deleted(self):
         '''It should not update a deleted dataset from the API and raise 401'''
         user = self.login()
@@ -479,6 +496,7 @@ class DatasetResourceAPITest(APITestCase):
         self.login()
         self.dataset = DatasetFactory(owner=self.user)
 
+    @attr('create')
     def test_create(self):
         data = ResourceFactory.attributes()
         with self.api_user():
@@ -488,6 +506,7 @@ class DatasetResourceAPITest(APITestCase):
         self.dataset.reload()
         self.assertEqual(len(self.dataset.resources), 1)
 
+    @attr('create')
     def test_create_2nd(self):
         self.dataset.resources.append(ResourceFactory())
         self.dataset.save()
@@ -500,6 +519,7 @@ class DatasetResourceAPITest(APITestCase):
         self.dataset.reload()
         self.assertEqual(len(self.dataset.resources), 2)
 
+    @attr('create')
     def test_create_with_file(self):
         '''It should create a resource from the API with a file'''
         user = self.login()
@@ -522,6 +542,7 @@ class DatasetResourceAPITest(APITestCase):
         self.assertTrue(
             dataset.resources[0].url.endswith('test.txt'))
 
+    @attr('update')
     def test_reorder(self):
         self.dataset.resources = ResourceFactory.build_batch(3)
         self.dataset.save()
@@ -538,6 +559,7 @@ class DatasetResourceAPITest(APITestCase):
         self.assertEqual([str(r.id) for r in self.dataset.resources],
                          [str(r['id']) for r in expected_order])
 
+    @attr('update')
     def test_update(self):
         resource = ResourceFactory()
         self.dataset.resources.append(resource)
@@ -562,6 +584,7 @@ class DatasetResourceAPITest(APITestCase):
         self.assertEqual(updated.url, data['url'])
         self.assertEqualDates(updated.published, now)
 
+    @attr('update')
     def test_bulk_update(self):
         resources = ResourceFactory.build_batch(2)
         self.dataset.resources.extend(resources)
@@ -594,6 +617,7 @@ class DatasetResourceAPITest(APITestCase):
         new_resource = self.dataset.resources[-1]
         self.assertEqualDates(new_resource.published, now)
 
+    @attr('update')
     def test_update_404(self):
         data = {
             'title': faker.sentence(),
@@ -606,6 +630,7 @@ class DatasetResourceAPITest(APITestCase):
                                         rid=str(ResourceFactory().id)), data)
         self.assert404(response)
 
+    @attr('update')
     def test_update_with_file(self):
         '''It should update a resource from the API with a file'''
         user = self.login()
@@ -831,6 +856,7 @@ class CommunityResourceAPITest(APITestCase):
         data = json.loads(response.data)
         self.assertEqual(data['id'], str(community_resource.id))
 
+    @attr('create')
     def test_community_resource_api_create(self):
         '''It should create a community resource from the API'''
         self.login()
@@ -853,6 +879,7 @@ class CommunityResourceAPITest(APITestCase):
         self.assertEqual(community_resource.owner, self.user)
         self.assertIsNone(community_resource.organization)
 
+    @attr('create')
     def test_community_resource_api_create_as_org(self):
         '''It should create a community resource as org from the API'''
         user = self.login()
@@ -879,6 +906,7 @@ class CommunityResourceAPITest(APITestCase):
         self.assertEqual(community_resource.organization, org)
         self.assertIsNone(community_resource.owner)
 
+    @attr('update')
     def test_community_resource_api_update(self):
         '''It should update a community resource from the API'''
         self.login()
@@ -894,6 +922,7 @@ class CommunityResourceAPITest(APITestCase):
         self.assertEqual(CommunityResource.objects.first().description,
                          'new description')
 
+    @attr('update')
     def test_community_resource_api_update_with_file(self):
         '''It should update a community resource file from the API'''
         user = self.login()

--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -233,7 +233,8 @@ class DatasetAPITest(APITestCase):
     def test_dataset_api_update_without_resources(self):
         '''It should update a dataset from the API without resources'''
         user = self.login()
-        dataset = VisibleDatasetFactory(owner=user)
+        dataset = DatasetFactory(owner=user,
+                                 resources=ResourceFactory.build_batch(3))
         initial_length = len(dataset.resources)
         data = dataset.to_dict()
         del data['resources']
@@ -242,7 +243,8 @@ class DatasetAPITest(APITestCase):
         self.assert200(response)
         self.assertEqual(Dataset.objects.count(), 1)
 
-        dataset = Dataset.objects.first()
+        dataset.reload()
+        self.assertEqual(dataset.description, data['description'])
         self.assertEqual(len(dataset.resources), initial_length)
 
     def test_dataset_api_update_with_extras(self):

--- a/udata/tests/factories.py
+++ b/udata/tests/factories.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 
+from hashlib import sha1
 from uuid import uuid4
 
 import factory
@@ -55,22 +56,32 @@ class AdminFactory(UserFactory):
         return [admin_role]
 
 
-class CommunityResourceFactory(MongoEngineFactory):
+class ChecksumFactory(MongoEngineFactory):
+    class Meta:
+        model = models.Checksum
+
+    type = 'sha1'
+    value = factory.LazyAttribute(lambda o: sha1(faker.word()).hexdigest())
+
+
+class BaseResourceFactory(MongoEngineFactory):
+    title = factory.LazyAttribute(lambda o: faker.sentence())
+    description = factory.LazyAttribute(lambda o: faker.text())
+    filetype = 'file'
+    url = factory.LazyAttribute(lambda o: faker.url())
+    checksum = factory.SubFactory(ChecksumFactory)
+    mime = factory.LazyAttribute(lambda o: faker.mime_type('text'))
+    filesize = factory.LazyAttribute(lambda o: faker.pyint())
+
+
+class CommunityResourceFactory(BaseResourceFactory):
     class Meta:
         model = models.CommunityResource
 
-    title = factory.LazyAttribute(lambda o: faker.sentence())
-    description = factory.LazyAttribute(lambda o: faker.text())
-    url = factory.LazyAttribute(lambda o: faker.url())
 
-
-class ResourceFactory(MongoEngineFactory):
+class ResourceFactory(BaseResourceFactory):
     class Meta:
         model = models.Resource
-
-    title = factory.LazyAttribute(lambda o: faker.sentence())
-    description = factory.LazyAttribute(lambda o: faker.text())
-    url = factory.LazyAttribute(lambda o: faker.url())
 
 
 class DatasetFactory(MongoEngineFactory):

--- a/udata/tests/forms/test_form_field.py
+++ b/udata/tests/forms/test_form_field.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from werkzeug.datastructures import MultiDict
+
+from udata.forms import ModelForm, fields
+from udata.models import db
+from udata.tests import TestCase
+from udata.tests.factories import faker
+
+
+class Nested(db.EmbeddedDocument):
+    id = db.AutoUUIDField()
+    name = db.StringField()
+
+
+class Fake(db.Document):
+    name = db.StringField()
+    nested = db.EmbeddedDocumentField(Nested)
+
+
+class NestedForm(ModelForm):
+    model_class = Nested
+    name = fields.StringField(validators=[fields.validators.required()])
+
+
+class NestedFormWithId(NestedForm):
+    id = fields.UUIDField()
+
+
+class FormFieldTest(TestCase):
+    def factory(self, data=None, instance=None, id=True, **kwargs):
+        if id:
+            nested_form = NestedFormWithId
+        else:
+            nested_form = NestedForm
+
+        class FakeForm(ModelForm):
+            model_class = Fake
+            name = fields.StringField()
+            nested = fields.FormField(nested_form, **kwargs)
+
+        if isinstance(data, MultiDict):
+            return FakeForm(data, obj=instance, instance=instance)
+        else:
+            return FakeForm.from_json(data, obj=instance, instance=instance)
+
+    def test_empty_data(self):
+        fake = Fake()
+        form = self.factory()
+        form.populate_obj(fake)
+
+        self.assertIsNone(fake.nested)
+
+    def test_with_one_valid_data(self):
+        fake = Fake()
+        form = self.factory(MultiDict({'nested-name': 'John Doe'}))
+
+        form.validate()
+        self.assertEqual(form.errors, {})
+
+        form.populate_obj(fake)
+
+        self.assertIsInstance(fake.nested, Nested)
+        self.assertEqual(fake.nested.name, 'John Doe')
+
+    def test_with_one_valid_json(self):
+        fake = Fake()
+        form = self.factory({'nested': {'name': 'John Doe'}})
+
+        form.validate()
+        self.assertEqual(form.errors, {})
+
+        form.populate_obj(fake)
+
+        self.assertIsInstance(fake.nested, Nested)
+        self.assertEqual(fake.nested.name, 'John Doe')
+
+    def test_with_initial_elements(self):
+        fake = Fake.objects.create(nested=Nested(name=faker.name()))
+        new_name = faker.name()
+        form = self.factory({'nested': {'name': new_name}}, fake)
+
+        form.validate()
+        self.assertEqual(form.errors, {})
+
+        form.populate_obj(fake)
+
+        self.assertIsNotNone(fake.nested.id)
+        self.assertEqual(fake.nested.name, new_name)
+
+    def test_with_non_submitted_initial_elements(self):
+        fake = Fake.objects.create(nested=Nested(name=faker.name()))
+        initial_id = fake.nested.id
+        initial_name = fake.nested.name
+        form = self.factory({'name': faker.word()}, fake)
+
+        form.validate()
+        self.assertEqual(form.errors, {})
+
+        form.populate_obj(fake)
+
+        self.assertEqual(fake.nested.id, initial_id)
+        self.assertEqual(fake.nested.name, initial_name)
+
+    def test_update_initial_elements(self):
+        fake = Fake.objects.create(nested=Nested(name=faker.name()))
+        initial_id = fake.nested.id
+        new_name = faker.name()
+        form = self.factory({'nested': {'name': new_name}}, fake)
+
+        form.validate()
+        self.assertEqual(form.errors, {})
+
+        form.populate_obj(fake)
+
+        self.assertEqual(fake.nested.id, initial_id)
+        self.assertEqual(fake.nested.name, new_name)


### PR DESCRIPTION
This is the first part of fix on checksum handling (and globally on resources saving and validations).
This one fix bad checksum in database and raise ValidationError if not present ensuring it's not happening again.