### PR TITLE
Ensure that map.vue does not fail if GeoJSON has no property

### DIFF
--- a/js/components/widgets/map.vue
+++ b/js/components/widgets/map.vue
@@ -65,29 +65,23 @@ export default {
 
 
         L.tileLayer(TILES_URL, TILES_CONFIG).addTo(this.map);
-        // this.layer.addTo(this.map);
-        // this.map.fitBounds(this.layer.getBounds());
     },
     watch: {
         'geojson': function(json) {
             if (json) {
                 this.layer = L.geoJson(json, {
                     onEachFeature: function (feature, layer) {
-                        layer.bindPopup(feature.properties.name);
-                        layer.on("mouseover", function () {
-                            layer.openPopup();
-                        });
-                        layer.on("mouseout", function () {
-                            layer.closePopup();
-                        });
+                        if (feature.properties && feature.properties.name) {
+                            layer.bindPopup(feature.properties.name);
+                            layer.on("mouseover", function () {
+                                layer.openPopup();
+                            });
+                            layer.on("mouseout", function () {
+                                layer.closePopup();
+                            });
+                        }
                     }
                 });
-                // this.layer.on('mouseover', function(e) {
-                //     e.layer.openPopup();
-                // });
-                // this.layer.on('mouseout', function(e) {
-                //     e.layer.closePopup();
-                // });
                 this.layer.addTo(this.map);
                 this.map.fitBounds(this.layer.getBounds());
             }

--- a/js/components/widgets/map.vue
+++ b/js/components/widgets/map.vue
@@ -70,14 +70,20 @@ export default {
         'geojson': function(json) {
             if (json) {
                 this.layer = L.geoJson(json, {
-                    onEachFeature: function (feature, layer) {
+                    onEachFeature: (feature, layer) => {
                         if (feature.properties && feature.properties.name) {
                             layer.bindPopup(feature.properties.name);
-                            layer.on("mouseover", function () {
+                            layer.on("mouseover", function() {
                                 layer.openPopup();
                             });
-                            layer.on("mouseout", function () {
-                                layer.closePopup();
+                            layer.on("mouseout", function() {
+                                if (layer.closePopup) {
+                                    layer.closePopup();
+                                } else {
+                                    layer.eachLayer(function(layer) {
+                                        layer.closePopup();
+                                    });
+                                }
                             });
                         }
                     }

--- a/js/dataset/display.js
+++ b/js/dataset/display.js
@@ -160,13 +160,21 @@ function load_coverage_map() {
 
     layer = L.geoJson(null, {
         onEachFeature: function(feature, layer) {
-            layer.bindPopup(feature.properties.name);
-            layer.on('mouseover', function() {
-                layer.openPopup();
-            });
-            layer.on('mouseout', function() {
-                layer.closePopup();
-            });
+            if (feature.properties && feature.properties.name) {
+                layer.bindPopup(feature.properties.name);
+                layer.on('mouseover', function() {
+                    layer.openPopup();
+                });
+                layer.on('mouseout', function() {
+                    if (layer.closePopup) {
+                        layer.closePopup();
+                    } else {
+                        layer.eachLayer(function(layer) {
+                            layer.closePopup();
+                        });
+                    }
+                });
+            }
         }
     });
 


### PR DESCRIPTION
When using the geom field from spatial coverage (manualy submited coverage zone), the map.vue fails because not properties are present in the GeoJSON.
This PR avoid this by checking the feature presence.

It raises a question: what do we chose to display when we have both `geom` and `zones` in the spatial coverage. The current behavior is to display the manualy submitted `geom`.