### PR TITLE
Missing mails

### DIFF
--- a/udata/core/discussions/models.py
+++ b/udata/core/discussions/models.py
@@ -46,5 +46,5 @@ class Discussion(db.Document):
     @property
     def external_url(self):
         return self.subject.url_for(
-            _anchor='discussion-{ id }'.format(id=self.id),
+            _anchor='discussion-{id}'.format(id=self.id),
             _external=True)

--- a/udata/tests/__init__.py
+++ b/udata/tests/__init__.py
@@ -21,6 +21,7 @@ from werkzeug.wrappers import Request
 
 from udata import settings
 from udata.app import create_app
+from udata.mail import mail_sent
 from udata.models import db
 from udata.search import es
 
@@ -107,6 +108,19 @@ class TestCase(BaseTestCase):
                 mock_handler.called,
                 'Signal "{0}" should have been emitted'.format(signal_name)
             )
+
+    @contextmanager
+    def capture_mails(self):
+        mails = []
+
+        def on_mail_sent(mail):
+            mails.append(mail)
+
+        mail_sent.connect(on_mail_sent)
+
+        yield mails
+
+        mail_sent.disconnect(on_mail_sent)
 
 
 class WebTestMixin(object):

--- a/udata/tests/test_issues.py
+++ b/udata/tests/test_issues.py
@@ -6,12 +6,16 @@ from datetime import datetime
 from flask import url_for
 
 from udata.models import db, Dataset, DatasetIssue, ReuseIssue, Member
+from udata.core.dataset.views import blueprint as dataset_bp
 from udata.core.user.views import blueprint as user_bp
 from udata.core.issues.models import Issue, Message
 from udata.core.issues.actions import issues_for
 from udata.core.issues.notifications import issues_notifications
 from udata.core.issues.signals import (
     on_new_issue, on_new_issue_comment, on_issue_closed
+)
+from udata.core.issues.tasks import (
+    notify_new_issue, notify_new_issue_comment, notify_issue_closed
 )
 
 from frontend import FrontTestCase
@@ -537,3 +541,80 @@ class IssuesNotificationsTest(TestCase, DBTestMixin):
             self.assertEqual(details['title'], issue.title)
             self.assertEqual(details['subject']['id'], issue.subject.id)
             self.assertEqual(details['subject']['type'], 'dataset')
+
+
+class IssuesMailsTest(TestCase, DBTestMixin):
+    def create_app(self):
+        app = super(IssuesMailsTest, self).create_app()
+        app.register_blueprint(user_bp)
+        app.register_blueprint(dataset_bp)
+        return app
+
+    def test_new_issue_mail(self):
+        user = UserFactory()
+        owner = UserFactory()
+        message = Message(content=faker.sentence(), posted_by=user)
+        issue = DatasetIssue.objects.create(
+            subject=DatasetFactory(owner=owner),
+            user=user,
+            title=faker.sentence(),
+            discussion=[message]
+        )
+
+        with self.capture_mails() as mails:
+            notify_new_issue(issue)
+
+        # Should have sent one mail to the owner
+        self.assertEqual(len(mails), 1)
+        self.assertEqual(mails[0].recipients[0], owner.email)
+
+    def test_new_issue_comment_mail(self):
+        owner = UserFactory()
+        poster = UserFactory()
+        commenter = UserFactory()
+        message = Message(content=faker.sentence(), posted_by=poster)
+        new_message = Message(content=faker.sentence(), posted_by=commenter)
+        issue = DatasetIssue.objects.create(
+            subject=DatasetFactory(owner=owner),
+            user=poster,
+            title=faker.sentence(),
+            discussion=[message, new_message]
+        )
+
+        # issue = DatasetIssueFactory()
+        with self.capture_mails() as mails:
+            notify_new_issue_comment(issue, message=new_message)
+
+        # Should have sent one mail to the owner and the other participants
+        # and no mail to the commenter
+        expected_recipients = (owner.email, poster.email)
+        self.assertEqual(len(mails), len(expected_recipients))
+        for mail in mails:
+            self.assertIn(mail.recipients[0], expected_recipients)
+            self.assertNotIn(commenter.email, mail.recipients)
+
+    def test_closed_issue_mail(self):
+        owner = UserFactory()
+        poster = UserFactory()
+        commenter = UserFactory()
+        message = Message(content=faker.sentence(), posted_by=poster)
+        second_message = Message(content=faker.sentence(), posted_by=commenter)
+        closing_message = Message(content=faker.sentence(), posted_by=owner)
+        issue = DatasetIssue.objects.create(
+            subject=DatasetFactory(owner=owner),
+            user=poster,
+            title=faker.sentence(),
+            discussion=[message, second_message, closing_message]
+        )
+
+        # issue = DatasetIssueFactory()
+        with self.capture_mails() as mails:
+            notify_issue_closed(issue, message=closing_message)
+
+        # Should have sent one mail to each participant
+        # and no mail to the closer
+        expected_recipients = (poster.email, commenter.email)
+        self.assertEqual(len(mails), len(expected_recipients))
+        for mail in mails:
+            self.assertIn(mail.recipients[0], expected_recipients)
+            self.assertNotIn(owner.email, mail.recipients)


### PR DESCRIPTION
This PR:
- add mail testing facilities
- fix the mailer choice (use FakeMailer when debugging or testing and real mailer in production)
- test issues and discussions signals
- test issues and discussions mails
- fix discussions mails not being sent.

I think another PR is required to test all the mails and, even better, group test by modules.