### PR TITLE
Workaround babel startsWith not being transpiled in some case

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,4 @@
 {
     "presets": ["es2015"],
-    "plugins": ["transform-runtime"],
     "comments": false
 }

--- a/js/admin.js
+++ b/js/admin.js
@@ -6,6 +6,9 @@ import '../less/admin.less';
 // Catch all errors
 import 'raven';
 
+// ES6 environment
+import 'babel-polyfill';
+
 import $ from 'jquery';
 import 'bootstrap';
 

--- a/js/dashboard.js
+++ b/js/dashboard.js
@@ -1,3 +1,6 @@
+// ES6 environment
+import 'babel-polyfill';
+
 // Catch all errors
 import 'raven';
 

--- a/js/dataset/display.js
+++ b/js/dataset/display.js
@@ -1,6 +1,9 @@
 /**
  * Dataset display page JS module
  */
+
+// ES6 environment
+import 'babel-polyfill';
 import $ from 'jquery';
 import config from 'config';
 import log from 'logger';

--- a/js/home.js
+++ b/js/home.js
@@ -6,6 +6,9 @@ import '../less/home.less';
 // Catch all errors
 // require('raven');
 
+// ES6 environment
+import 'babel-polyfill';
+
 import $ from 'jquery';
 import 'bootstrap';
 

--- a/js/organization/display.js
+++ b/js/organization/display.js
@@ -1,6 +1,10 @@
 /**
  * Default JS module
  */
+
+// ES6 environment
+import 'babel-polyfill';
+
 import $ from 'jquery';
 import log from 'logger';
 import Auth from 'auth';

--- a/js/post/display.js
+++ b/js/post/display.js
@@ -2,6 +2,9 @@
  * Post display page JS module
  */
 
+// ES6 environment
+import 'babel-polyfill';
+
 import $ from 'jquery';
 import log from 'logger';
 

--- a/js/reuse/display.js
+++ b/js/reuse/display.js
@@ -1,6 +1,10 @@
 /**
  * Reuse display page JS module
  */
+
+// ES6 environment
+import 'babel-polyfill';
+
 import $ from 'jquery';
 import log from 'logger';
 

--- a/js/search.js
+++ b/js/search.js
@@ -1,6 +1,10 @@
 /**
  * Common search features
  */
+
+// ES6 environment
+import 'babel-polyfill';
+
 import $ from 'jquery';
 import log from 'logger';
 import 'search/temporal-coverage-facet';

--- a/js/site.js
+++ b/js/site.js
@@ -5,6 +5,9 @@
  */
 require('../less/site.less');
 
+// ES6 environment
+import 'babel-polyfill';
+
 // Catch all errors
 // require('raven');
 

--- a/js/site/map.js
+++ b/js/site/map.js
@@ -1,3 +1,6 @@
+// ES6 environment
+import 'babel-polyfill';
+
 import $ from 'jquery';
 import log from 'logger';
 import Map from 'dashboard/map';

--- a/js/topic/display.js
+++ b/js/topic/display.js
@@ -1,3 +1,6 @@
+// ES6 environment
+import 'babel-polyfill';
+
 import $ from 'jquery';
 import 'jQuery.dotdotdot';
 

--- a/js/user/display.js
+++ b/js/user/display.js
@@ -1,6 +1,10 @@
 /*
  * User display page
  */
+
+// ES6 environment
+import 'babel-polyfill';
+
 import log from 'logger';
 import 'widgets/follow-btn';
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "babel-core": "^6.4.0",
     "babel-eslint": "^5.0.0-beta6",
     "babel-loader": "^6.2.1",
-    "babel-plugin-transform-runtime": "^6.4.3",
     "babel-preset-es2015": "^6.3.13",
     "chai": "^3.4.0",
     "chai-jquery": "^2.0.0",
@@ -63,7 +62,7 @@
   "dependencies": {
     "Chart.StackedBar.js": "regaddi/Chart.StackedBar.js#1.0.3",
     "admin-lte": "^2.3.2",
-    "babel-runtime": "^5.6.25",
+    "babel-polyfill": "^6.5.0",
     "bootstrap": "^3.3.5",
     "bootstrap-datepicker": "^1.5.1",
     "bootstrap-daterangepicker": "^2.1.17",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -66,6 +66,7 @@ module.exports = {
         loaders: {
             css: css_loader,
             less: less_loader,
+            js: 'babel'
         }
     },
     plugins: [


### PR DESCRIPTION
IE does not have natively `String.prototype.startsWith`.
Given how Babel is working when using babel-runtime, polyfills are not applied to prototype and there is some case where babel-runtime is not able to detected variable type and to transpile the polyfill.

This PR fix this on `variable.startsWith`.