### PR TITLE
Improve the checksum migration

### DIFF
--- a/udata/migrations/2016-03-02-fix-resources-checksums.js
+++ b/udata/migrations/2016-03-02-fix-resources-checksums.js
@@ -1,0 +1,36 @@
+/*
+ * Ensure all resources with checksum have a checksum type
+ *
+ * Same migration as udata:2016-01-25-fix-resources-checksums.js just optimized.
+ *
+ * Needed to reapply because of https://github.com/etalab/udata/pull/328
+ * not fixing the creation case  and data corruption was still happening
+ * until https://github.com/etalab/udata/pull/371
+ */
+
+var datasets = db.dataset.find({
+    resources: {$elemMatch: {
+        'checksum.value': {$exists: true},
+        'checksum.type': {$exists: false}
+    }}
+});
+
+print('Candidates: ' + datasets.count());
+
+var counter = 0;
+var count = 0;
+
+datasets.forEach(function(dataset) {
+    var resources = dataset.resources.map(function(resource) {
+        if (resource.checksum && resource.checksum.value && !resource.checksum.type) {
+            resource.checksum.type = 'sha1';
+            count++;
+        }
+        return resource;
+    });
+    var result = db.dataset.update({_id: dataset._id},
+                                   {$set: {resources: resources}});
+    counter += result.nModified;
+});
+print(count, 'resources modified.');
+print(counter, 'datasets modified.');


### PR DESCRIPTION
This PR improve the badchecksum detection migration.

It will need to unrecord the migration to apply it again (it's safe).

```shell
$ udata db unrecord udata 2016-01-25-fix-resources-checksums.js
-> Removing migration udata:2016-01-25-fix-resources-checksums.js

$ udata db migrate
-> udata:2015-05-06-migrate-issues.js ................................... [Skipped]
-> udata:2015-06-10-public-service-to-badges.js ......................... [Skipped]
-> gouvfr:2015-07-10-dataconnexions-badges.js ........................... [Skipped]
-> udata:2015-08-19-migrate-resource-published.js ....................... [Skipped]
-> gouvfr:2015-09-14-dataconnexions-6.js ................................ [Skipped]
-> udata:2015-09-14-generic-badges.js ................................... [Skipped]
-> udata:2015-09-23-community-resources.js .............................. [Skipped]
-> udata:2015-09-25-migrate-harvest-sources-validation.js ............... [Skipped]
-> gouvfr:2015-09-28-fix-maaf-harvester-doublouns.js .................... [Skipped]
-> udata:2015-10-08-migrate-resources-field-names.js .................... [Skipped]
-> udata:2015-10-19-deduplicate-badges.js ............................... [Skipped]
-> udata:2015-11-16-remove-supplier.js .................................. [Skipped]
-> udata:2015-11-23-set-uuid-as-community-resources-id.js ............... [Skipped]
-> udata:2016-01-21-set-uuid-for-community-resources.js ................. [Skipped]
-> udata:2016-01-21-set-uuid-for-resources.js ........................... [Skipped]
-> udata:2016-01-25-fix-resources-checksums.js .......................... [Apply]
│
│ Candidates: 47
│ 97 resources modified.
│ 47 datasets modified.
│
└──[OK]

-> udata:2016-02-03-clean-topic-datasets.js ............................. [Skipped]
```