### PR TITLE
Ensure non submitted nested properties (JSON) are not in the instanciated

### DIFF
--- a/udata/core/spatial/tests/test_fields.py
+++ b/udata/core/spatial/tests/test_fields.py
@@ -31,13 +31,10 @@ class SpatialCoverageFieldTest(TestCase):
         form = FakeForm()
         self.assertEqual(form.spatial.zones._value(), '')
         self.assertEqual(form.spatial.zones.data, [])
-        # self.assertEqual(form.spatial.granularity._value(), '')
         self.assertEqual(form.spatial.granularity.data, 'other')
         self.assertIsNone(form.spatial.geom.data)
 
-        self.assertEqual(form.spatial.data, {
-            'zones': [], 'granularity': 'other', 'geom': None
-        })
+        self.assertIsNone(form.spatial.data)
 
         fake = Fake()
         form.populate_obj(fake)

--- a/udata/forms/fields.py
+++ b/udata/forms/fields.py
@@ -201,7 +201,7 @@ class FormField(FieldHelper, fields.FormField):
         super(FormField, self).__init__(FormWrapper(form_class),
                                         *args, **kwargs)
         self.prefix = '{0}-'.format(self.name)
-        self.has_data = False
+        self._formdata = None
 
     def process(self, formdata, data=unset_value):
         self._formdata = formdata
@@ -213,8 +213,6 @@ class FormField(FieldHelper, fields.FormField):
                             'as it gets errors from the enclosed form.')
 
         # Run normal validation only if there is data for this form
-        self.has_data = bool(self._formdata)
-        self.has_data &= any(k.startswith(self.prefix) for k in self._formdata)
         if self.has_data:
             return self.form.validate()
         return True
@@ -225,6 +223,16 @@ class FormField(FieldHelper, fields.FormField):
         if getattr(self.form_class, 'model_class', None) and not self._obj:
             self._obj = self.form_class.model_class()
         super(FormField, self).populate_obj(obj, name)
+
+    @property
+    def data(self):
+        return self.form.data if self.has_data else None
+
+    @property
+    def has_data(self):
+        return self._formdata and any(
+            k.startswith(self.prefix) for k in self._formdata
+        )
 
 
 def nullable_text(value):

--- a/udata/tests/dataset/test_dataset_model.py
+++ b/udata/tests/dataset/test_dataset_model.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 
 from mongoengine import post_save
 
-from udata.models import db, Dataset
+from udata.models import db, Dataset, Resource
 
 from .. import TestCase, DBTestMixin
 from ..factories import (
@@ -60,6 +60,21 @@ class DatasetModelTest(TestCase, DBTestMixin):
 
         with self.assert_emit(*expected_signals):
             dataset.add_resource(ResourceFactory())
+        self.assertEqual(len(dataset.resources), 1)
+
+        with self.assert_emit(*expected_signals):
+            dataset.add_resource(resource)
+        self.assertEqual(len(dataset.resources), 2)
+        self.assertEqual(dataset.resources[0].id, resource.id)
+
+    def test_add_resource_without_checksum(self):
+        user = UserFactory()
+        dataset = DatasetFactory(owner=user)
+        resource = ResourceFactory(checksum=None)
+        expected_signals = post_save, Dataset.after_save, Dataset.on_update
+
+        with self.assert_emit(*expected_signals):
+            dataset.add_resource(ResourceFactory(checksum=None))
         self.assertEqual(len(dataset.resources), 1)
 
         with self.assert_emit(*expected_signals):

--- a/udata/tests/forms/test_form_field.py
+++ b/udata/tests/forms/test_form_field.py
@@ -11,7 +11,7 @@ from udata.tests.factories import faker
 
 class Nested(db.EmbeddedDocument):
     id = db.AutoUUIDField()
-    name = db.StringField()
+    name = db.StringField(required=True)
 
 
 class Fake(db.Document):
@@ -116,3 +116,14 @@ class FormFieldTest(TestCase):
 
         self.assertEqual(fake.nested.id, initial_id)
         self.assertEqual(fake.nested.name, new_name)
+
+    def test_create_with_non_submitted_elements(self):
+        form = self.factory({'name': faker.word()})
+
+        form.validate()
+        self.assertEqual(form.errors, {})
+
+        fake = form.save()
+
+        self.assertIsNotNone(fake.name)
+        self.assertIsNone(fake.nested)

--- a/udata/tests/forms/test_nested_model_list_field.py
+++ b/udata/tests/forms/test_nested_model_list_field.py
@@ -10,7 +10,7 @@ from udata.tests.factories import faker
 
 
 class SubNested(db.EmbeddedDocument):
-    name = db.StringField()
+    name = db.StringField(required=True)
 
 
 class Nested(db.EmbeddedDocument):
@@ -243,6 +243,21 @@ class NestedModelListFieldTest(TestCase):
             self.assertEqual(nested.id, id)
             self.assertEqual(nested.name, names[idx])
         self.assertIsNotNone(fake.nested[2].id)
+
+    def test_non_submitted_subnested(self):
+        form = self.factory({'nested': [
+            {'name': faker.name()},
+            {'name': faker.name(), 'sub': {'name': faker.name()}},
+        ]}, sub=True)
+
+        form.validate()
+        self.assertEqual(form.errors, {})
+
+        fake = form.save()
+
+        self.assertEqual(len(fake.nested), 2)
+        self.assertIsNone(fake.nested[0].sub)
+        self.assertIsNotNone(fake.nested[1].sub)
 
     def test_reorder_initial_elements(self):
         fake = Fake.objects.create(nested=[


### PR DESCRIPTION
This PR is the missing part of #328 and fixes the case of nested object (non)instanciation on creation when the data is optionnal and non present (main case: checksum on resources)