### PR TITLE
Fix datasetless communautary resources deletion

### DIFF
--- a/js/components/dataset/communityresource/list.vue
+++ b/js/components/dataset/communityresource/list.vue
@@ -58,8 +58,9 @@ export default {
     },
     events: {
         'datatable:item:click'(community) {
+            const dataset_id = community.dataset ? community.dataset.id : 'deleted';
             this.$go({name: 'dataset-community-resource', params: {
-                oid: community.dataset.id, rid: community.id
+                oid: dataset_id, rid: community.id
             }});
         }
     }

--- a/udata/commands/purge.py
+++ b/udata/commands/purge.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import logging
+
+# from flask.ext.script import Command, Option
+
+from udata.commands import manager
+
+from udata.core.dataset.tasks import purge_datasets
+from udata.core.organization.tasks import purge_organizations
+from udata.core.reuse.tasks import purge_reuses
+
+log = logging.getLogger(__name__)
+
+
+@manager.command
+def purge():
+    '''permanently remove data flagged as deleted'''
+    log.info('Purging datasets')
+    purge_datasets()
+
+    log.info('Purging reuses')
+    purge_reuses()
+
+    log.info('Purging organizations')
+    purge_organizations()
+
+    log.info('Done')


### PR DESCRIPTION
This PR:

- [x] add the purge command (avoiding to launch each purge job manually)
- [x] force admin modal display for communautary resources without dataset (has been deleted)