### PR TITLE
Fix bad reuse-discussion route name

### DIFF
--- a/js/admin.routes.js
+++ b/js/admin.routes.js
@@ -111,7 +111,7 @@ router.map({
                 }
             },
             'discussion/:discussion_id/': {
-                name: 'reuse-issue',
+                name: 'reuse-discussion',
                 component: function(resolve) {
                     require(['./components/discussions/modal.vue'], resolve);
                 }


### PR DESCRIPTION
This PR fix wrong and duplicate route name for `reuse-discussion` in admin