### PR TITLE
Ensure tags are unique in dataset tag test

### DIFF
--- a/udata/tests/api/test_datasets_api.py
+++ b/udata/tests/api/test_datasets_api.py
@@ -17,7 +17,7 @@ from . import APITestCase
 from ..factories import (
     badge_factory, faker, DatasetFactory, VisibleDatasetFactory,
     CommunityResourceFactory, ResourceFactory, OrganizationFactory,
-    AdminFactory, UserFactory, LicenseFactory
+    AdminFactory, UserFactory, LicenseFactory, unique_string
 )
 
 from nose.plugins.attrib import attr
@@ -156,7 +156,7 @@ class DatasetAPITest(APITestCase):
     def test_dataset_api_create_tags(self):
         '''It should create a dataset from the API'''
         data = DatasetFactory.attributes()
-        data['tags'] = faker.words(nb=3)
+        data['tags'] = [unique_string() for _ in range(3)]
         with self.api_user():
             response = self.post(url_for('api.datasets'), data)
         self.assertStatus(response, 201)


### PR DESCRIPTION
This PR fix this annoying randomly failing test du to words collisions.