### PR TITLE
Clear console output

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -59,7 +59,7 @@ const API = new SwaggerClient({
  * @return {Object}      The resolved schema
  */
 API.resolve = function($ref) {
-    const def = $ref.replace(config.api_specs, '').replace('#/definitions/', '');
+    const def = $ref.split('#')[1].replace('/definitions/', '');
     return this.definitions[def];
 };
 

--- a/js/auth.js
+++ b/js/auth.js
@@ -6,7 +6,7 @@ import config from 'config';
 import Notify from 'notify';
 import i18n from 'i18n';
 
-const DEFAULT_NEED_ROLE = i18n._('Role "{role}" is required');
+const DEFAULT_NEED_ROLE = i18n._('Role "{role}" is required', {role: '{role}'});
 
 
 export const user = config.user;

--- a/js/components/dataset/quality-section.vue
+++ b/js/components/dataset/quality-section.vue
@@ -18,7 +18,7 @@
 export default {
     props: {
         title: String,
-        condition: Boolean,
+        condition: [Boolean, null],
         ok: String,
         ko: String,
         info: [String, null],

--- a/js/components/dataset/quality.vue
+++ b/js/components/dataset/quality.vue
@@ -38,7 +38,7 @@
     <qa-section :title="_('Up-to-date')"
         :condition="quality.update_in <= 0"
         :ok="_('That is great!')"
-        :ko="_('Need an update since {days} days.', {days:quality.update_in})">
+        :ko="_('Need an update since {days} days.', {days: quality.update_in || '0'})">
         <p>{{ _('Proposing up-to-date and incremental data makes it possible for reusers to establish datavisualisations on the long term.') }}</p>
         <p v-if="quality.frequency">{{ _('You currently set your frequency to {frequency}.', {frequency: quality.frequency}) }}</p>
         <p v-if="!quality.frequency">{{ _('You currently have no frequency set for that dataset, is that pertinent?') }}</p>

--- a/js/form/common.js
+++ b/js/form/common.js
@@ -33,6 +33,8 @@ define(['jquery', 'i18n', 'jquery-validation-dist', 'bootstrap' ], function($, i
     // jQuery validate
     $('form.validation').validate(rules);
 
+    const interpolation = {defaultVariables: {'O': '{O}', '1': '{1}', 'ISO': '{ISO}'}};
+
     // jQuery validate
     $.extend($.validator.messages, {
         required: i18n._('valid-required'),
@@ -40,17 +42,17 @@ define(['jquery', 'i18n', 'jquery-validation-dist', 'bootstrap' ], function($, i
         email: i18n._('valid-email'),
         url: i18n._('valid-url'),
         date: i18n._('valid-date'),
-        dateISO: i18n._('valid-date-iso'),
+        dateISO: i18n._('valid-date-iso', {interpolation: interpolation}),
         number: i18n._('valid-number'),
         digits: i18n._('valid-digits'),
         creditcard: i18n._('valid-creditcard'),
         equalTo: i18n._('valid-equal-to'),
-        maxlength: $.validator.format(i18n._('valid-maxlength')),
-        minlength: $.validator.format(i18n._('valid-minlength')),
-        rangelength: $.validator.format(i18n._('valid-range-length')),
-        range: $.validator.format(i18n._('valid-range')),
-        max: $.validator.format(i18n._('valid-max')),
-        min: $.validator.format(i18n._('valid-min'))
+        maxlength: $.validator.format(i18n._('valid-maxlength', {interpolation: interpolation})),
+        minlength: $.validator.format(i18n._('valid-minlength', {interpolation: interpolation})),
+        rangelength: $.validator.format(i18n._('valid-range-length', {interpolation: interpolation})),
+        range: $.validator.format(i18n._('valid-range', {interpolation: interpolation})),
+        max: $.validator.format(i18n._('valid-max', {interpolation: interpolation})),
+        min: $.validator.format(i18n._('valid-min', {interpolation: interpolation}))
     });
 
     // Form help messages as popover on info sign

--- a/package.json
+++ b/package.json
@@ -95,12 +95,12 @@
     "sortablejs": "^1.4.2",
     "source-sans-pro": "^2.0.10",
     "spin.js": "^2.3.2",
-    "swagger-client": "2.1.11",
+    "swagger-client": "2.1.13",
     "swagger-ui": "2.1.4",
     "tv4": "^1.2.7",
     "typeahead.js": "corejavascript/typeahead.js",
     "typeahead.js-bootstrap3.less": "hyspace/typeahead.js-bootstrap3.less#v0.2.3",
-    "vue": "1.0.15",
-    "vue-router": "0.7.10"
+    "vue": "1.0.18",
+    "vue-router": "0.7.11"
   }
 }


### PR DESCRIPTION
This pull-request cleans the console output by:

- upgrading to latest versions of vue.js, vue-router and swagger-client (they removed some useless warnings)
- providing the missing i18n interpolations
- fixing some warnings on the quality widget