### PR TITLE
Downgrade Vue.js to 1.0.17

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "tv4": "^1.2.7",
     "typeahead.js": "corejavascript/typeahead.js",
     "typeahead.js-bootstrap3.less": "hyspace/typeahead.js-bootstrap3.less#v0.2.3",
-    "vue": "1.0.18",
+    "vue": "1.0.17",
     "vue-router": "0.7.11"
   }
 }


### PR DESCRIPTION
In Vue.js 1.0.18 `PageList` pagination doesn't work as expected: the datatable widget doesn't detect the page changed and is locked on the first page (used on resource list and harvest job list).

This PR downgrade to Vue.js 1.0.17 where it works fine.