### PR TITLE
Js tools improvements

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -141,7 +141,6 @@ rules:
     space-before-blocks: 2                  # http://eslint.org/docs/rules/space-before-blocks
     space-before-function-paren: [2, never] # http://eslint.org/docs/rules/space-before-function-paren
     space-infix-ops: 2                      # http://eslint.org/docs/rules/space-infix-ops
-    space-return-throw-case: 2              # http://eslint.org/docs/rules/space-return-throw-case
     spaced-comment:                         # http://eslint.org/docs/rules/spaced-comment
         - 2
         - always

--- a/docs/testing-code.md
+++ b/docs/testing-code.md
@@ -55,18 +55,23 @@ For more advanced usage, you can use the npm dedicated run-scripts:
 ```shell
 # Single run in PhantomJS
 $ npm -s run test:unit
-# Watch changes and doesn't prelaunch a browser
+# Watch and run tests on change in PhantomJS
 $ npm -s run test:watch
 ```
 
 You can pass any option to karma after the `--`:
 
 ```bash
-# watch changes, with PhantomJS prelaunched
-$ npm -s run test:watch -- --browsers PhantomJS
+# Run tests a in new Chrome and Firefox instances
+$ npm -s run test:unit -- --browsers Chrome,Firefox
 # Single run with JUnit xml output
 $ npm -s run test:unit -- --reporters mocha,junit
 ```
+
+!!! note
+    If using Chrome launcher without `chrome` being on the `$PATH` (or using Chromium),
+    you need to specify the binary path by settings the environment variable
+    `CHROME_BIN`
 
 See [the official karma documentation][karma] for more details about the possible parameters.
 

--- a/docs/testing-code.md
+++ b/docs/testing-code.md
@@ -75,6 +75,32 @@ $ npm -s run test:unit -- --reporters mocha,junit
 
 See [the official karma documentation][karma] for more details about the possible parameters.
 
+### Testing on IE
+
+You can run the test suite under Modern.ie VMs installed with either [ievms][]
+or [iectrl][] (installation is detailled on websites).
+
+```bash
+# Install IE11 under Win7 (time to have one or more coffee!)
+$ iectrl install 11
+# Run tests under IE11
+$ npm -s run test:unit -- --browsers 'IE11 - Win7'
+```
+
+!!! note
+    uData ensure compatibility for IE officialy supported by Microsoft.
+    Right now, it's IE11.
+
+You maybe need to manually close the first time popup on first run.
+To do so, launch the VM then launch the test suite:
+
+```bash
+$ iectrl start 11
+$ npm -s run test:unit -- --browsers 'IE11 - Win7'
+# You can close it after
+$ iectrl close 11
+```
+
 ## Integration tests
 
 We use [Watai][] which is using [webdriver API][] on top of [Selenium][].
@@ -110,3 +136,5 @@ Check out the [Watai tutorial][] to add your own tests!
 [chai]: http://chaijs.com/
 [chai-plugins]: http://chaijs.com/plugins/
 [sinon.js]: http://sinonjs.org/
+[ievms]: http://xdissent.github.io/ievms/
+[iectrl]: http://xdissent.github.io/iectrl/

--- a/docs/testing-code.md
+++ b/docs/testing-code.md
@@ -88,7 +88,7 @@ $ npm -s run test:unit -- --browsers 'IE11 - Win7'
 ```
 
 !!! note
-    uData ensure compatibility for IE officialy supported by Microsoft.
+    uData ensure compatibility for IE [officialy supported by Microsoft][ie-support].
     Right now, it's IE11.
 
 You maybe need to manually close the first time popup on first run.
@@ -138,3 +138,4 @@ Check out the [Watai tutorial][] to add your own tests!
 [sinon.js]: http://sinonjs.org/
 [ievms]: http://xdissent.github.io/ievms/
 [iectrl]: http://xdissent.github.io/iectrl/
+[ie-support]: https://www.microsoft.com/en-us/WindowsForBusiness/End-of-IE-support

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -106,8 +106,8 @@ module.exports = function(config) {
 
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        // browsers: ['Chrome', 'Firefox', 'PhantomJS'],
-        // browsers: ['PhantomJS'],
+        // browsers: ['Chrome', 'Firefox', 'PhantomJS']
+        browsers: ['PhantomJS'],
 
         // Continuous Integration mode
         // if true, Karma captures browsers, runs the tests and exits
@@ -118,6 +118,8 @@ module.exports = function(config) {
             require('karma-mocha'),
             require('karma-mocha-reporter'),
             require('karma-phantomjs-launcher'),
+            require('karma-firefox-launcher'),
+            require('karma-chrome-launcher'),
             require('karma-sourcemap-loader'),
             require('karma-fixture'),
             require('karma-sinon-chai'),

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -120,6 +120,7 @@ module.exports = function(config) {
             require('karma-phantomjs-launcher'),
             require('karma-firefox-launcher'),
             require('karma-chrome-launcher'),
+            require('karma-ievms'),
             require('karma-sourcemap-loader'),
             require('karma-fixture'),
             require('karma-sinon-chai'),

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "karma-chrome-launcher": "^0.2.3",
     "karma-firefox-launcher": "^0.1.7",
     "karma-fixture": "^0.2.5",
+    "karma-ievms": "^0.1.0",
     "karma-junit-reporter": "^0.4.1",
     "karma-mocha": "^0.2.2",
     "karma-mocha-reporter": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "mocha": "^2.3.4",
     "mocha-loader": "^0.7.1",
     "null-loader": "^0.1.1",
-    "phantomjs": "^1.9.18",
+    "phantomjs-prebuilt": "^2.1.7",
     "style-loader": "^0.13.0",
     "vue-hot-reload-api": "^1.2.2",
     "vue-html-loader": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "assets:build": "webpack -p --progress",
     "widgets:watch": "webpack -d -c --progress --watch --config webpack.widgets.config.js",
     "test:watch": "export NODE_ENV=test && WATCH=true karma start",
-    "test:unit": "export NODE_ENV=test && karma start --browsers PhantomJS --single-run",
+    "test:unit": "export NODE_ENV=test && karma start --single-run",
     "lint": "eslint js/ --ext .vue,.js"
   },
   "repository": {
@@ -36,6 +36,8 @@
     "json-loader": "^0.5.4",
     "karma": "0.13.22",
     "karma-chai-dom": "^1.1.0",
+    "karma-chrome-launcher": "^0.2.3",
+    "karma-firefox-launcher": "^0.1.7",
     "karma-fixture": "^0.2.5",
     "karma-junit-reporter": "^0.4.1",
     "karma-mocha": "^0.2.2",

--- a/specs/plugins/markdown.specs.js
+++ b/specs/plugins/markdown.specs.js
@@ -16,7 +16,7 @@ describe('Markdown plugin', function() {
             const is_comment = node.nodeType === Node.COMMENT_NODE;
             const is_empty_text = node.nodeType === Node.TEXT_NODE && !/\S/.test(node.nodeValue);
             if (is_comment || is_empty_text) {
-                node.remove();
+                node.parentNode.removeChild(node);
             }
         });
         return el;


### PR DESCRIPTION
This pull-request:
- remove a legacy ESLint rule
- give some coherence to `browsers` behavior on karma (PhantomJS by default unless overriden)
- allow to run directly into Firefox and/or Chrome/Chromium
- update to PhantomJS 2 (prebuilt and non failing on download)
- allow to run karma test under IE11 (using iectrl/ievms)
- fix a tests not running under IE11