### PR TITLE
Upgrade dependencies

### DIFF
--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -4,7 +4,7 @@ blinker==1.4
 celery==3.1.18
 celerybeat-mongo==0.0.8
 chardet
-CommonMark==0.5.4
+CommonMark==0.6.3
 elasticsearch==2.3.0
 Flask-BabelEx==0.9.3
 Flask-Cache==0.13.1

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -1,8 +1,8 @@
 awesome-slugify==1.6.5
 bleach==1.4.2
 blinker==1.4
-celery==3.1.18
-celerybeat-mongo==0.0.8
+celery==3.1.23
+celerybeat-mongo==0.0.10
 chardet
 CommonMark==0.6.3
 elasticsearch==2.3.0
@@ -12,7 +12,7 @@ flask-fs==0.1
 Flask-Gravatar==0.4.2
 Flask-Login==0.2.11
 Flask-Mail==0.9.1
-flask-mongoengine==0.7.1
+flask-mongoengine==0.7.5
 Flask-Navigation==0.2.0
 Flask-OAuthlib==0.9.2
 flask-restplus==0.7.2
@@ -24,7 +24,7 @@ Flask-WTF==0.12
 Flask==0.10.1
 html2text
 lxml
-mongoengine==0.10.0
+mongoengine==0.10.6
 msgpack-python==0.4.7
 pillow
 py-bcrypt==0.4

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -5,8 +5,8 @@ celery==3.1.18
 celerybeat-mongo==0.0.8
 chardet
 CommonMark==0.5.4
-elasticsearch==1.6.0
-Flask-BabelEx==0.9.2
+elasticsearch==2.3.0
+Flask-BabelEx==0.9.3
 Flask-Cache==0.13.1
 flask-fs==0.1
 Flask-Gravatar==0.4.2
@@ -14,14 +14,13 @@ Flask-Login==0.2.11
 Flask-Mail==0.9.1
 flask-mongoengine==0.7.1
 Flask-Navigation==0.2.0
-Flask-OAuthlib==0.9.1
+Flask-OAuthlib==0.9.2
 flask-restplus==0.7.2
 Flask-Script==2.0.5
 Flask-Security==1.7.4
-Flask-Sitemap==0.1.0
+Flask-Sitemap==0.2.0
 Flask-Themes2==0.1.4
-Flask-Uploads==0.1.3
-Flask-WTF==0.11.0
+Flask-WTF==0.12
 Flask==0.10.1
 html2text
 lxml
@@ -30,15 +29,15 @@ msgpack-python==0.4.7
 pillow
 py-bcrypt==0.4
 pyliblzma==0.5.3
-python-dateutil==2.4.2
+python-dateutil==2.5.2
 pytz
 PyYAML==3.11
 redis
 requests
-unicodecsv==0.13.0
+unicodecsv==0.14.1
 voluptuous
 wtforms-json==0.2.10
-wtforms==2.0.2
+wtforms==2.1
 xmltodict
 geojson>=1.3.1
 

--- a/requirements/install.pip
+++ b/requirements/install.pip
@@ -10,14 +10,14 @@ Flask-BabelEx==0.9.3
 Flask-Cache==0.13.1
 flask-fs==0.1
 Flask-Gravatar==0.4.2
-Flask-Login==0.2.11
+Flask-Login==0.3.2
 Flask-Mail==0.9.1
 flask-mongoengine==0.7.5
 Flask-Navigation==0.2.0
 Flask-OAuthlib==0.9.2
 flask-restplus==0.7.2
 Flask-Script==2.0.5
-Flask-Security==1.7.4
+Flask-Security==1.7.5
 Flask-Sitemap==0.2.0
 Flask-Themes2==0.1.4
 Flask-WTF==0.12

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -1,7 +1,7 @@
 Flask-Testing==0.4.2
-factory-boy==2.5.2
-fake-factory==0.5.2
-mock==1.3.0
+factory-boy==2.6.1
+fake-factory==0.5.7
+mock==2.0.0
 nose>=1.3.0
 rednose>=0.4.1
 nose-exclude>=0.2.0

--- a/udata/api/__init__.py
+++ b/udata/api/__init__.py
@@ -72,7 +72,7 @@ class UDataApi(Api):
 
         @wraps(func)
         def wrapper(*args, **kwargs):
-            if not current_user.is_authenticated():
+            if not current_user.is_authenticated:
                 self.abort(401)
 
             if permission is not None:
@@ -87,7 +87,7 @@ class UDataApi(Api):
         '''Authentify the user if credentials are given'''
         @wraps(func)
         def wrapper(*args, **kwargs):
-            if current_user.is_authenticated():
+            if current_user.is_authenticated:
                 return func(*args, **kwargs)
 
             apikey = request.headers.get(HEADER_API_KEY)

--- a/udata/auth/views.py
+++ b/udata/auth/views.py
@@ -98,6 +98,6 @@ def ensure_https_authenticated_users():
     # Force authenticated users to use https
     if (not current_app.config.get('TESTING', False) and
             current_app.config.get('USE_SSL', False) and
-            current_user.is_authenticated() and not
+            current_user.is_authenticated and not
             request.is_secure):
         return redirect(request.url.replace('http://', 'https://'))

--- a/udata/core/badges/models.py
+++ b/udata/core/badges/models.py
@@ -71,7 +71,7 @@ class BadgeMixin(object):
             raise db.ValidationError(msg.format(model=self.__class__.__name__,
                                                 kind=kind))
         badge = Badge(kind=kind)
-        if current_user.is_authenticated():
+        if current_user.is_authenticated:
             badge.created_by = current_user.id
 
         self.update(__raw__={

--- a/udata/core/dataset/activities.py
+++ b/udata/core/dataset/activities.py
@@ -41,7 +41,7 @@ class UserDeletedDataset(DatasetRelatedActivity, Activity):
 @Dataset.on_create.connect
 def on_user_created_dataset(dataset):
     if (not dataset.private and current_user and
-            current_user.is_authenticated()):
+            current_user.is_authenticated):
         user = current_user._get_current_object()
         organization = dataset.organization
         write_activity.delay(UserCreatedDataset, user, dataset, organization)
@@ -50,7 +50,7 @@ def on_user_created_dataset(dataset):
 @Dataset.on_update.connect
 def on_user_updated_dataset(dataset):
     if (not dataset.private and current_user and
-            current_user.is_authenticated()):
+            current_user.is_authenticated):
         user = current_user._get_current_object()
         organization = dataset.organization
         write_activity.delay(UserUpdatedDataset, user, dataset, organization)
@@ -59,7 +59,7 @@ def on_user_updated_dataset(dataset):
 @Dataset.on_delete.connect
 def on_user_deleted_dataset(dataset):
     if (not dataset.private and current_user and
-            current_user.is_authenticated()):
+            current_user.is_authenticated):
         user = current_user._get_current_object()
         organization = dataset.organization
         write_activity.delay(UserDeletedDataset, user, dataset, organization)

--- a/udata/core/followers/views.py
+++ b/udata/core/followers/views.py
@@ -13,6 +13,6 @@ blueprint = I18nBlueprint('followers', __name__)
 @blueprint.app_template_global()
 @blueprint.app_template_filter()
 def is_following(obj):
-    if not current_user.is_authenticated():
+    if not current_user.is_authenticated:
         return False
     return Follow.objects.is_following(current_user._get_current_object(), obj)

--- a/udata/core/jobs/forms.py
+++ b/udata/core/jobs/forms.py
@@ -32,6 +32,12 @@ class PeriodicTaskForm(ModelForm):
     task = fields.StringField(_('Tasks'))
     enabled = fields.BooleanField(_('Enabled'))
 
+    def save(self, commit=True, **kwargs):
+        '''PeriodicTask is now dynamic and save behavior changed'''
+        if not self.instance:
+            self.instance = self.model_class()  # Force populate_obj in super()
+        return super(PeriodicTaskForm, self).save(commit, **kwargs)
+
 
 class CrontabTaskForm(PeriodicTaskForm):
     crontab = fields.FormField(CrontabForm)

--- a/udata/core/jobs/forms.py
+++ b/udata/core/jobs/forms.py
@@ -33,7 +33,10 @@ class PeriodicTaskForm(ModelForm):
     enabled = fields.BooleanField(_('Enabled'))
 
     def save(self, commit=True, **kwargs):
-        '''PeriodicTask is now dynamic and save behavior changed'''
+        '''
+        PeriodicTask is dynamic and save behavior changed
+        See: https://github.com/zakird/celerybeat-mongo/commit/dfbbd20edde91134b57f5406d0ce4eac59d6899b
+        '''
         if not self.instance:
             self.instance = self.model_class()  # Force populate_obj in super()
         return super(PeriodicTaskForm, self).save(commit, **kwargs)

--- a/udata/core/organization/activities.py
+++ b/udata/core/organization/activities.py
@@ -34,7 +34,7 @@ class UserUpdatedOrganization(OrgRelatedActivity, Activity):
 
 @Organization.on_create.connect
 def on_user_created_organization(organization):
-    if current_user and current_user.is_authenticated():
+    if current_user and current_user.is_authenticated:
         user = current_user._get_current_object()
         write_activity.delay(
             UserCreatedOrganization, user, organization,
@@ -43,7 +43,7 @@ def on_user_created_organization(organization):
 
 @Organization.on_update.connect
 def on_user_updated_organization(organization):
-    if current_user and current_user.is_authenticated():
+    if current_user and current_user.is_authenticated:
         user = current_user._get_current_object()
         write_activity.delay(
             UserUpdatedOrganization, user, organization,

--- a/udata/core/organization/permissions.py
+++ b/udata/core/organization/permissions.py
@@ -32,7 +32,7 @@ class OrganizationPrivatePermission(Permission):
 
 @identity_loaded.connect
 def inject_organization_needs(sender, identity):
-    if current_user.is_authenticated():
+    if current_user.is_authenticated:
         for org in Organization.objects(members__user=current_user.id):
             membership = get_by(org.members, 'user',
                                 current_user._get_current_object())

--- a/udata/core/organization/views.py
+++ b/udata/core/organization/views.py
@@ -30,7 +30,7 @@ blueprint = I18nBlueprint('organizations', __name__,
 
 @blueprint.before_app_request
 def set_g_user_orgs():
-    if current_user.is_authenticated():
+    if current_user.is_authenticated:
         g.user_organizations = current_user.organizations
 
 

--- a/udata/core/reuse/activities.py
+++ b/udata/core/reuse/activities.py
@@ -41,7 +41,7 @@ class UserDeletedReuse(ReuseRelatedActivity, Activity):
 
 @Reuse.on_create.connect
 def on_user_created_reuse(reuse):
-    if not reuse.private and current_user and current_user.is_authenticated():
+    if not reuse.private and current_user and current_user.is_authenticated:
         user = current_user._get_current_object()
         organization = reuse.organization
         write_activity.delay(UserCreatedReuse, user, reuse, organization)
@@ -49,7 +49,7 @@ def on_user_created_reuse(reuse):
 
 @Reuse.on_update.connect
 def on_user_updated_reuse(reuse):
-    if not reuse.private and current_user and current_user.is_authenticated():
+    if not reuse.private and current_user and current_user.is_authenticated:
         user = current_user._get_current_object()
         organization = reuse.organization
         write_activity.delay(UserUpdatedReuse, user, reuse, organization)
@@ -57,7 +57,7 @@ def on_user_updated_reuse(reuse):
 
 @Reuse.on_delete.connect
 def on_user_deleted_reuse(reuse):
-    if not reuse.private and current_user and current_user.is_authenticated():
+    if not reuse.private and current_user and current_user.is_authenticated:
         user = current_user._get_current_object()
         organization = reuse.organization
         write_activity.delay(UserDeletedReuse, user, reuse, organization)

--- a/udata/core/spatial/tests/factories.py
+++ b/udata/core/spatial/tests/factories.py
@@ -19,7 +19,7 @@ class SpatialCoverageFactory(MongoEngineFactory):
     class Meta:
         model = SpatialCoverage
 
-    geom = factory.LazyAttribute(lambda o: faker.multipolygon())
+    geom = factory.Faker('multipolygon')
     granularity = factory.LazyAttribute(random_spatial_granularity)
 
 
@@ -29,9 +29,9 @@ class GeoZoneFactory(MongoEngineFactory):
 
     id = factory.LazyAttribute(lambda o: '/'.join((o.level, o.code)))
     level = factory.LazyAttribute(lambda o: unique_string())
-    name = factory.LazyAttribute(lambda o: faker.city())
-    code = factory.LazyAttribute(lambda o: faker.postcode())
-    geom = factory.LazyAttribute(lambda o: faker.multipolygon())
+    name = factory.Faker('city')
+    code = factory.Faker('postcode')
+    geom = factory.Faker('multipolygon')
 
 
 class GeoLevelFactory(MongoEngineFactory):
@@ -39,4 +39,4 @@ class GeoLevelFactory(MongoEngineFactory):
         model = GeoLevel
 
     id = factory.LazyAttribute(lambda o: unique_string())
-    name = factory.LazyAttribute(lambda o: faker.name())
+    name = factory.Faker('name')

--- a/udata/core/user/activities.py
+++ b/udata/core/user/activities.py
@@ -70,7 +70,7 @@ class UserFollowedOrganization(FollowActivity, OrgRelatedActivity, Activity):
 
 @on_follow.connect
 def write_activity_on_follow(follow, **kwargs):
-    if current_user.is_authenticated():
+    if current_user.is_authenticated:
         if isinstance(follow.following, Dataset):
             write_activity.delay(
                 UserFollowedDataset, current_user._get_current_object(),
@@ -92,7 +92,7 @@ def write_activity_on_follow(follow, **kwargs):
 @on_new_discussion.connect
 @on_new_discussion_comment.connect
 def write_activity_on_discuss(discussion, **kwargs):
-    if current_user.is_authenticated():
+    if current_user.is_authenticated:
         if isinstance(discussion.subject, Dataset):
             write_activity.delay(
                 UserDiscussedDataset, current_user._get_current_object(),

--- a/udata/features/territories/views.py
+++ b/udata/features/territories/views.py
@@ -88,7 +88,7 @@ def render_territory(territory):
                 town_datasets.append(dataset)
             else:
                 other_datasets.append(dataset)
-            editable_datasets.append(current_user.is_authenticated() and
+            editable_datasets.append(current_user.is_authenticated and
                                      DatasetEditPermission(dataset).can())
     context = {
         'territory': territory,

--- a/udata/forms/fields.py
+++ b/udata/forms/fields.py
@@ -552,7 +552,7 @@ class DateRangeField(FieldHelper, fields.StringField):
 
 def default_owner():
     '''Default to current_user if authenticated'''
-    if current_user.is_authenticated():
+    if current_user.is_authenticated:
         return current_user._get_current_object()
 
 
@@ -570,7 +570,7 @@ class CurrentUserField(FieldHelper, ModelField, fields.HiddenField):
 
     def pre_validate(self, form):
         if self.data:
-            if current_user.is_anonymous():
+            if current_user.is_anonymous:
                 raise validators.ValidationError(
                     _('You must be authenticated'))
             elif not admin_permission and current_user.id != self.data.id:
@@ -593,7 +593,7 @@ class PublishAsField(FieldHelper, ModelField, fields.HiddenField):
 
     def pre_validate(self, form):
         if self.data:
-            if not current_user.is_authenticated():
+            if not current_user.is_authenticated:
                 raise validators.ValidationError(
                     _('You must be authenticated'))
             elif not OrganizationPrivatePermission(self.data).can():

--- a/udata/frontend/markdown.py
+++ b/udata/frontend/markdown.py
@@ -68,8 +68,8 @@ def mdstrip(value, length=None, end='…'):
 
 
 def init_app(app):
-    parser = CommonMark.DocParser  # Not an instance because not thread-safe(?)
-    renderer = CommonMark.HTMLRenderer()
+    parser = CommonMark.Parser  # Not an instance because not thread-safe(?)
+    renderer = CommonMark.HtmlRenderer()
     app.extensions['markdown'] = UDataMarkdown(app, parser, renderer)
 
     app.add_template_filter(mdstrip)

--- a/udata/harvest/actions.py
+++ b/udata/harvest/actions.py
@@ -77,7 +77,7 @@ def validate_source(ident, comment=None):
     source.validation.on = datetime.now()
     source.validation.comment = comment
     source.validation.state = VALIDATION_ACCEPTED
-    if current_user.is_authenticated():
+    if current_user.is_authenticated:
         source.validation.by = current_user._get_current_object()
     source.save()
     launch(ident)
@@ -90,7 +90,7 @@ def reject_source(ident, comment):
     source.validation.on = datetime.now()
     source.validation.comment = comment
     source.validation.state = VALIDATION_REFUSED
-    if current_user.is_authenticated():
+    if current_user.is_authenticated:
         source.validation.by = current_user._get_current_object()
     source.save()
     return source

--- a/udata/harvest/tests/factories.py
+++ b/udata/harvest/tests/factories.py
@@ -6,28 +6,24 @@ import factory
 from flask.signals import Namespace
 
 from factory.mongoengine import MongoEngineFactory
-from faker import Faker
 
 from udata.tests.factories import DatasetFactory
 
 from .. import backends
 from ..models import HarvestSource, HarvestJob
 
-fake = Faker()
-
 
 def dtfactory(start, end):
-    return factory.LazyAttribute(
-        lambda o: fake.date_time_between(start_date=start, end_date=end))
+    return factory.Faker('date_time_between', start_date=start, end_date=end)
 
 
 class HarvestSourceFactory(MongoEngineFactory):
     class Meta:
         model = HarvestSource
 
-    name = factory.LazyAttribute(lambda o: fake.name())
-    url = factory.LazyAttribute(lambda o: fake.url())
-    description = factory.LazyAttribute(lambda o: fake.text())
+    name = factory.Faker('name')
+    url = factory.Faker('url')
+    description = factory.Faker('text')
 
 
 class HarvestJobFactory(MongoEngineFactory):

--- a/udata/harvest/tests/test_actions.py
+++ b/udata/harvest/tests/test_actions.py
@@ -13,11 +13,11 @@ from udata.models import Dataset, PeriodicTask
 
 from udata.tests import TestCase, DBTestMixin
 from udata.tests.factories import (
-    OrganizationFactory, UserFactory, DatasetFactory
+    OrganizationFactory, UserFactory, DatasetFactory, faker
 )
 
 from .factories import (
-    fake, HarvestSourceFactory, HarvestJobFactory,
+    HarvestSourceFactory, HarvestJobFactory,
     mock_initialize, mock_process, DEFAULT_COUNT as COUNT
 )
 from ..models import (
@@ -90,7 +90,7 @@ class HarvestActionsTest(DBTestMixin, TestCase):
             self.assertIn(source, result)
 
     def test_create_source(self):
-        source_url = fake.url()
+        source_url = faker.url()
 
         with self.assert_emit(signals.harvest_source_created):
             source = actions.create_source('Test source',
@@ -220,8 +220,8 @@ class HarvestActionsTest(DBTestMixin, TestCase):
     def test_unschedule(self):
         periodic_task = PeriodicTask.objects.create(
             task='harvest',
-            name=fake.name(),
-            description=fake.sentence(),
+            name=faker.name(),
+            description=faker.sentence(),
             enabled=True,
             crontab=PeriodicTask.Crontab()
         )

--- a/udata/harvest/tests/test_models.py
+++ b/udata/harvest/tests/test_models.py
@@ -5,8 +5,8 @@ import logging
 
 
 from udata.tests import TestCase, DBTestMixin
+from udata.tests.factories import faker
 
-from .factories import fake
 from ..models import HarvestSource
 
 
@@ -15,7 +15,7 @@ log = logging.getLogger(__name__)
 
 class HarvestSourceTest(DBTestMixin, TestCase):
     def test_defaults(self):
-        source = HarvestSource.objects.create(name='Test', url=fake.url())
+        source = HarvestSource.objects.create(name='Test', url=faker.url())
         self.assertEqual(source.name, 'Test')
         self.assertEqual(source.slug, 'test')
 

--- a/udata/i18n.py
+++ b/udata/i18n.py
@@ -108,7 +108,7 @@ def lazy_pgettext(*args, **kwargs):
 
 def _default_lang(user=None):
     user = user or current_user
-    if user.is_authenticated() and user.prefered_language:
+    if user.is_authenticated and user.prefered_language:
         return user.prefered_language
     else:
         return current_app.config['DEFAULT_LANGUAGE']

--- a/udata/tasks.py
+++ b/udata/tasks.py
@@ -91,8 +91,9 @@ def init_app(app):
     app.config.setdefault('CELERY_MONGODB_SCHEDULER_DB', default_name)
 
     from udata.models import db
-    default_url = 'mongodb://{host}:{port}'.format(
-        host=db.connection.host, port=db.connection.port)
+    with app.app_context():
+        default_url = 'mongodb://{host}:{port}'.format(
+            host=db.connection.host, port=db.connection.port)
     app.config.setdefault('CELERY_MONGODB_SCHEDULER_URL', default_url)
 
     celery.conf.update(app.config)

--- a/udata/templates/apidoc.html
+++ b/udata/templates/apidoc.html
@@ -40,7 +40,7 @@
             <div class="col-xs-12">
                 <p>
                     {{ _('In order to be able to execute write operations,') }}
-                    {% if current_user.is_authenticated() %}
+                    {% if current_user.is_authenticated %}
                         {{ _(
                             'you first need to obtain an %(apikey)s in your profile settings.',
                             apikey='<a href="%s#apikey">%s</a>'|format(

--- a/udata/templates/header.html
+++ b/udata/templates/header.html
@@ -34,7 +34,7 @@
 
       <ul class="nav navbar-nav navbar-right collapse navbar-collapse">
         {# <li><a href="{{ url_for('front.metrics') }}">{{ _('Metrics') }}</a></li> #}
-        {% if current_user.is_authenticated() %}
+        {% if current_user.is_authenticated %}
         <li class="dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown">
             <img src="{{ current_user|avatar_url(20) }}"

--- a/udata/templates/macros/metadata.html
+++ b/udata/templates/macros/metadata.html
@@ -30,7 +30,7 @@
 <meta name="csrf-token" content="{{ csrf_token() }}" />
 <meta name="site-title" content="{{config.SITE_TITLE}}" />
 
-{% if current_user.is_authenticated() %}
+{% if current_user.is_authenticated %}
 <meta name="current-user" content="{{ current_user.id }}"
     data-slug="{{ current_user.slug }}"
     data-first_name="{{ current_user.first_name }}"

--- a/udata/templates/territories/territory.html
+++ b/udata/templates/territories/territory.html
@@ -70,7 +70,7 @@
         <div class="dataset-item--cta col-sm-12 bg-primary">
             <div class="format-label pull-left">+</div>
             <p>
-                {% if current_user.is_authenticated() %}
+                {% if current_user.is_authenticated %}
                     {% if has_pertinent_datasets %}
                         {{ _('Some of your datasets have an exact match!') }}<br/>
                         <a href="m&#x61;ilto:{{ config.TERRITORIES_EMAIL|obfuscate|safe }}">

--- a/udata/tests/factories.py
+++ b/udata/tests/factories.py
@@ -17,12 +17,23 @@ from .geojson_provider import GeoJsonProvider
 
 faker = Faker()
 faker.add_provider(GeoJsonProvider)
+factory.Faker.add_provider(GeoJsonProvider)
 
 
 def unique_string(length=None):
     '''Generate unique string'''
     string = str(uuid4())
     return string[:length] if length else string
+
+
+def unique_url():
+    '''Generate unique URLs'''
+    return '/'.join([faker.url(), unique_string()])
+
+
+def random_sha1():
+    '''Genrate random sha1'''
+    return sha1(faker.word()).hexdigest()
 
 
 class SiteSettingsFactory(MongoEngineFactory):
@@ -34,8 +45,8 @@ class SiteFactory(MongoEngineFactory):
     class Meta:
         model = models.Site
 
-    id = factory.LazyAttribute(lambda o: faker.word())
-    title = factory.LazyAttribute(lambda o: faker.name())
+    id = factory.Faker('word')
+    title = factory.Faker('name')
     settings = factory.SubFactory(SiteSettingsFactory)
 
 
@@ -43,9 +54,9 @@ class UserFactory(MongoEngineFactory):
     class Meta:
         model = models.User
 
-    first_name = factory.LazyAttribute(lambda o: faker.first_name())
-    last_name = factory.LazyAttribute(lambda o: faker.last_name())
-    email = factory.LazyAttribute(lambda o: faker.email())
+    first_name = factory.Faker('first_name')
+    last_name = factory.Faker('last_name')
+    email = factory.Faker('email')
     active = True
 
 
@@ -61,17 +72,17 @@ class ChecksumFactory(MongoEngineFactory):
         model = models.Checksum
 
     type = 'sha1'
-    value = factory.LazyAttribute(lambda o: sha1(faker.word()).hexdigest())
+    value = factory.LazyAttribute(lambda o: random_sha1())
 
 
 class BaseResourceFactory(MongoEngineFactory):
-    title = factory.LazyAttribute(lambda o: faker.sentence())
-    description = factory.LazyAttribute(lambda o: faker.text())
+    title = factory.Faker('sentence')
+    description = factory.Faker('text')
     filetype = 'file'
-    url = factory.LazyAttribute(lambda o: faker.url())
+    url = factory.Faker('url')
     checksum = factory.SubFactory(ChecksumFactory)
-    mime = factory.LazyAttribute(lambda o: faker.mime_type('text'))
-    filesize = factory.LazyAttribute(lambda o: faker.pyint())
+    mime = factory.Faker('mime_type', category='text')
+    filesize = factory.Faker('pyint')
 
 
 class CommunityResourceFactory(BaseResourceFactory):
@@ -88,8 +99,8 @@ class DatasetFactory(MongoEngineFactory):
     class Meta:
         model = models.Dataset
 
-    title = factory.LazyAttribute(lambda o: faker.sentence())
-    description = factory.LazyAttribute(lambda o: faker.text())
+    title = factory.Faker('sentence')
+    description = factory.Faker('text')
     frequency = 'unknown'
 
 
@@ -103,39 +114,38 @@ class DatasetIssueFactory(MongoEngineFactory):
     class Meta:
         model = models.DatasetIssue
 
-    title = factory.LazyAttribute(lambda o: faker.sentence())
+    title = factory.Faker('sentence')
 
 
 class DatasetDiscussionFactory(MongoEngineFactory):
     class Meta:
         model = models.DatasetDiscussion
 
-    title = factory.LazyAttribute(lambda o: faker.sentence())
+    title = factory.Faker('sentence')
 
 
 class MessageDiscussionFactory(MongoEngineFactory):
     class Meta:
         model = Message
 
-    content = factory.LazyAttribute(lambda o: faker.sentence())
+    content = factory.Faker('sentence')
 
 
 class OrganizationFactory(MongoEngineFactory):
     class Meta:
         model = models.Organization
 
-    name = factory.LazyAttribute(lambda o: faker.sentence())
-    description = factory.LazyAttribute(lambda o: faker.text())
+    name = factory.Faker('sentence')
+    description = factory.Faker('text')
 
 
 class ReuseFactory(MongoEngineFactory):
     class Meta:
         model = models.Reuse
 
-    title = factory.LazyAttribute(lambda o: faker.sentence())
-    description = factory.LazyAttribute(lambda o: faker.text())
-    url = factory.LazyAttribute(
-        lambda o: '/'.join([faker.url(), unique_string()]))
+    title = factory.Faker('sentence')
+    description = factory.Faker('text')
+    url = factory.LazyAttribute(lambda o: unique_url())
     type = FuzzyChoice(models.REUSE_TYPES.keys())
 
 
@@ -150,15 +160,15 @@ class LicenseFactory(MongoEngineFactory):
         model = models.License
 
     id = factory.Sequence(lambda n: '{0}-{1}'.format(faker.word(), n))
-    title = factory.LazyAttribute(lambda o: faker.sentence())
+    title = factory.Faker('sentence')
 
 
 class TopicFactory(MongoEngineFactory):
     class Meta:
         model = models.Topic
 
-    name = factory.LazyAttribute(lambda o: faker.sentence())
-    description = factory.LazyAttribute(lambda o: faker.text())
+    name = factory.Faker('sentence')
+    description = factory.Faker('text')
     tags = factory.LazyAttribute(lambda o: [unique_string() for _ in range(3)])
 
     @factory.lazy_attribute
@@ -174,10 +184,10 @@ class PostFactory(MongoEngineFactory):
     class Meta:
         model = models.Post
 
-    name = factory.LazyAttribute(lambda o: faker.sentence())
-    headline = factory.LazyAttribute(lambda o: faker.sentence())
-    content = factory.LazyAttribute(lambda o: faker.text())
-    private = factory.LazyAttribute(lambda o: False)
+    name = factory.Faker('sentence')
+    headline = factory.Faker('sentence')
+    content = factory.Faker('text')
+    private = False
 
     @factory.lazy_attribute
     def datasets(self):
@@ -191,7 +201,7 @@ class PostFactory(MongoEngineFactory):
 class TransferFactory(MongoEngineFactory):
     class Meta:
         model = models.Transfer
-    comment = factory.LazyAttribute(lambda o: faker.sentence())
+    comment = factory.Faker('sentence')
 
 
 def badge_factory(model):
@@ -208,5 +218,4 @@ class GeoZoneFactory(MongoEngineFactory):
     class Meta:
         model = models.GeoZone
 
-    geom = factory.LazyAttribute(
-        lambda o: [[[[1, 1], [1, 1]], [[1, 1], [1, 1]]]])
+    geom = factory.Faker('multipolygon')

--- a/udata/tests/workers/test_workers_api.py
+++ b/udata/tests/workers/test_workers_api.py
@@ -183,7 +183,7 @@ class JobsAPITest(APITestCase):
             'name': task.name,
             'description': 'New description',
             'task': task.task,
-            'crontab': task.crontab._data
+            'crontab': task.crontab.to_json()
         })
         self.assert403(response)
 
@@ -204,7 +204,7 @@ class JobsAPITest(APITestCase):
             'name': task.name,
             'description': 'New description',
             'task': task.task,
-            'crontab': task.crontab._data
+            'crontab': task.crontab.to_json()
         })
         self.assert200(response)
 

--- a/udata/tracking.py
+++ b/udata/tracking.py
@@ -11,6 +11,6 @@ def send_signal(signal, request, user, **kwargs):
         'user_ip': request.remote_addr
     }
     params.update(kwargs)
-    if user.is_authenticated():
+    if user.is_authenticated:
         params['uid'] = user.id
     signal.send(request.url, **params)


### PR DESCRIPTION
This PR upgrade to latest Python dependencies (all excluding flask-restplus) with the following changes:
- Flask-Login 0.3+ transform functions `is_*` to properties (See the related PRs: etalab/udata-gouvfr#/104 and etalab/udata-youckan#2)
- factory-boy provide a simpler and integrated way to use faker
- CommonMark upgraded to latest specs (and rename 2 classes)