### PR TITLE
Use site author instead of hardcoded Etalab

### DIFF
--- a/js/components/dataset/card.vue
+++ b/js/components/dataset/card.vue
@@ -7,7 +7,7 @@
         :src="certified" alt="certified"
         class="certified" data-toggle="popover"
         :data-title="_('Certified public service')"
-        :data-content="_('The identity of this public service public is certified by Etalab')"
+        :data-content="_('The identity of this public service public is certified by %(certifier)', certifier=config.SITE_AUTHOR)"
         data-container="body" data-trigger="hover"/>
     <div class="card-body">
         <h4>

--- a/js/components/dataset/card.vue
+++ b/js/components/dataset/card.vue
@@ -7,7 +7,7 @@
         :src="certified" alt="certified"
         class="certified" data-toggle="popover"
         :data-title="_('Certified public service')"
-        :data-content="_('The identity of this public service public is certified by %(certifier)', certifier=config.SITE_AUTHOR)"
+        :data-content="_('The identity of this public service is certified by %(certifier)s', certifier=config.SITE_AUTHOR)"
         data-container="body" data-trigger="hover"/>
     <div class="card-body">
         <h4>

--- a/js/components/organization/card.vue
+++ b/js/components/organization/card.vue
@@ -8,7 +8,7 @@
         :src="certified_stamp" alt="certified"
         class="certified" data-toggle="popover"
         :data-title="_('Certified public service')"
-        :data-content="_('The identity of this public service public is certified by %(certifier)', certifier=config.SITE_AUTHOR)"
+        :data-content="_('The identity of this public service is certified by %(certifier)s', certifier=config.SITE_AUTHOR)"
         data-container="body" data-trigger="hover"/>
     <div class="card-body">
         <h4>

--- a/js/components/organization/card.vue
+++ b/js/components/organization/card.vue
@@ -8,7 +8,7 @@
         :src="certified_stamp" alt="certified"
         class="certified" data-toggle="popover"
         :data-title="_('Certified public service')"
-        :data-content="_('The identity of this public service public is certified by Etalab')"
+        :data-content="_('The identity of this public service public is certified by %(certifier)', certifier=config.SITE_AUTHOR)"
         data-container="body" data-trigger="hover"/>
     <div class="card-body">
         <h4>

--- a/js/templates/dataset/card.hbs
+++ b/js/templates/dataset/card.hbs
@@ -8,7 +8,7 @@
         <img src="{{theme 'img/certified-stamp.png' }}" alt="certified"
             class="certified" data-toggle="popover"
             data-title="{{_ 'Certified public service' }}"
-            data-content="{{_ 'The identity of this public service is certified by %(certifier)', certifier=config.SITE_AUTHOR }}"
+            data-content="{{_ 'The identity of this public service is certified by %(certifier)s', certifier=config.SITE_AUTHOR }}"
             data-container="body" data-trigger="hover"/>
         {{/if}}
     {{else}}

--- a/js/templates/dataset/card.hbs
+++ b/js/templates/dataset/card.hbs
@@ -8,7 +8,7 @@
         <img src="{{theme 'img/certified-stamp.png' }}" alt="certified"
             class="certified" data-toggle="popover"
             data-title="{{_ 'Certified public service' }}"
-            data-content="{{_ 'The identity of this public service public is certified by Etalab' }}"
+            data-content="{{_ 'The identity of this public service is certified by %(certifier)', certifier=config.SITE_AUTHOR }}"
             data-container="body" data-trigger="hover"/>
         {{/if}}
     {{else}}

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -70,7 +70,7 @@ class Defaults(object):
     SITE_TITLE = 'uData'
     SITE_KEYWORDS = ['opendata', 'udata']
     SITE_AUTHOR_URL = None
-    SITE_AUTHOR = None
+    SITE_AUTHOR = 'Etalab'
     SITE_GITHUB_URL = 'https://github.com/etalab/udata'
     USE_SSL = False
 

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -70,7 +70,7 @@ class Defaults(object):
     SITE_TITLE = 'uData'
     SITE_KEYWORDS = ['opendata', 'udata']
     SITE_AUTHOR_URL = None
-    SITE_AUTHOR = 'Etalab'
+    SITE_AUTHOR = 'Udata'
     SITE_GITHUB_URL = 'https://github.com/etalab/udata'
     USE_SSL = False
 

--- a/udata/templates/dataset/card.html
+++ b/udata/templates/dataset/card.html
@@ -11,7 +11,7 @@
         <img src="{{ theme_static('img/certified-stamp.png') }}" alt="certified"
             class="certified" data-toggle="popover"
             data-title="{% trans %}Certified public service{% endtrans %}"
-            data-content="{% trans %}The identity of this public service public is certified by Etalab{% endtrans %}"
+            data-content="{{_('The identity of this public service is certified by %(certifier)', certifier=config.SITE_AUTHOR)}}"
             data-container="body" data-trigger="hover"/>
         {% endif %}
     {% else %}

--- a/udata/templates/dataset/card.html
+++ b/udata/templates/dataset/card.html
@@ -1,5 +1,6 @@
 {% cache cache_duration, 'dataset-card', dataset.id|string, g.lang_code %}
 {% set dataset_url = url_for('datasets.show', dataset=dataset) %}
+{% from theme('macros/certified.html') import badge_if_certified with context %}
 <div class="card dataset-card">
     {% if dataset.organization %}
         <a class="card-logo" href="{{ dataset_url }}">
@@ -7,13 +8,7 @@
                 src="{{ dataset.organization.logo(70)|placeholder('organization') }}"
                 width="70" height="70">
         </a>
-        {% if dataset.organization.public_service %}
-        <img src="{{ theme_static('img/certified-stamp.png') }}" alt="certified"
-            class="certified" data-toggle="popover"
-            data-title="{% trans %}Certified public service{% endtrans %}"
-            data-content="{{_('The identity of this public service is certified by %(certifier)', certifier=config.SITE_AUTHOR)}}"
-            data-container="body" data-trigger="hover"/>
-        {% endif %}
+        {{ badge_if_certified(dataset.organization) }}
     {% else %}
     <div class="card-logo">
         <img src="{{ ''|placeholder('organization') }}" alt="">

--- a/udata/templates/dataset/search-result.html
+++ b/udata/templates/dataset/search-result.html
@@ -1,4 +1,5 @@
 {% cache cache_duration, 'dataset-search-result', dataset.id|string, g.lang_code %}
+{% from theme('macros/certified.html') import badge_if_certified with context %}
 <li class="search-result dataset-result">
     <a href="{{ url_for('datasets.show', dataset=dataset) }}" title="{{ dataset.title }}">
         {% if dataset.organization %}
@@ -7,13 +8,7 @@
                 src="{{ dataset.organization.logo(70)|placeholder('organization') }}"
                 width="70" height="70">
         </div>
-            {% if dataset.organization.public_service %}
-            <img src="{{theme_static('img/certified-stamp.png')}}" alt="certified"
-                class="certified" data-toggle="popover"
-                data-title="{{ _('Certified public service') }}"
-                data-content="{{_('The identity of this public service is certified by %(certifier)', certifier=config.SITE_AUTHOR)}}"
-                data-container="body" data-placement="auto" data-trigger="hover"/>
-            {% endif %}
+        {{ badge_if_certified(dataset.organization) }}
         {% else %}
         <div class="result-logo pull-left">
             <img src="{{ ''|placeholder('organization') }}" alt="">

--- a/udata/templates/dataset/search-result.html
+++ b/udata/templates/dataset/search-result.html
@@ -11,7 +11,7 @@
             <img src="{{theme_static('img/certified-stamp.png')}}" alt="certified"
                 class="certified" data-toggle="popover"
                 data-title="{{ _('Certified public service') }}"
-                data-content="{{ _('The identity of this public service public is certified by Etalab') }}"
+                data-content="{{_('The identity of this public service is certified by %(certifier)', certifier=config.SITE_AUTHOR)}}"
                 data-container="body" data-placement="auto" data-trigger="hover"/>
             {% endif %}
         {% else %}

--- a/udata/templates/macros/certified.html
+++ b/udata/templates/macros/certified.html
@@ -1,0 +1,9 @@
+{% macro badge_if_certified(org) %}
+{% if org.public_service %}
+<img src="{{ theme_static('img/certified-stamp.png') }}" alt="certified"
+    class="certified" data-toggle="popover"
+    data-title="{{ _('Certified public service') }}"
+    data-content="{{_('The identity of this public service is certified by %(certifier)s', certifier=config.SITE_AUTHOR)}}"
+    data-container="body" data-trigger="hover"/>
+{% endif %}
+{% endmacro %}

--- a/udata/templates/organization/card.html
+++ b/udata/templates/organization/card.html
@@ -1,18 +1,12 @@
 {% cache cache_duration, 'org-card', organization.id|string, g.lang_code %}
+{% from theme('macros/certified.html') import badge_if_certified with context %}
 <div class="card organization-card">
     <a class="card-logo" href="{{ url_for('organizations.show', org=organization) }}">
         <img alt="{{ organization.title }}"
             src="{{ organization.logo(60)|placeholder('organization') }}"
             width="60" height="60">
     </a>
-    {% if organization.public_service %}
-    <img src="{{ theme_static('img/certified-stamp.png') }}" alt="certified"
-        class="certified" data-toggle="popover"
-        data-title="{{ _('Certified public service') }}"
-        data-content="{{ _('The identity of this public service is certified by %(certifier)', certifier=config.SITE_AUTHOR) }}"
-        data-container="body" data-trigger="hover"/>
-    {% endif %}
-
+    {{ badge_if_certified(org) }}
     <div class="card-body">
         <h4>
             <a href="{{ url_for('organizations.show', org=organization) }}" title="{{organization.name}}">

--- a/udata/templates/organization/card.html
+++ b/udata/templates/organization/card.html
@@ -6,7 +6,7 @@
             src="{{ organization.logo(60)|placeholder('organization') }}"
             width="60" height="60">
     </a>
-    {{ badge_if_certified(org) }}
+    {{ badge_if_certified(organization) }}
     <div class="card-body">
         <h4>
             <a href="{{ url_for('organizations.show', org=organization) }}" title="{{organization.name}}">

--- a/udata/templates/organization/card.html
+++ b/udata/templates/organization/card.html
@@ -9,7 +9,7 @@
     <img src="{{ theme_static('img/certified-stamp.png') }}" alt="certified"
         class="certified" data-toggle="popover"
         data-title="{{ _('Certified public service') }}"
-        data-content="{{ _('The identity of this public service public is certified by Etalab') }}"
+        data-content="{{ _('The identity of this public service is certified by %(certifier)', certifier=config.SITE_AUTHOR) }}"
         data-container="body" data-trigger="hover"/>
     {% endif %}
 

--- a/udata/templates/organization/edit_base.html
+++ b/udata/templates/organization/edit_base.html
@@ -1,5 +1,6 @@
 {% extends theme('layouts/form.html') %}
 {% import 'macros/forms.html' as forms with context %}
+{% from theme('macros/certified.html') import badge_if_certified with context %}
 {% set tab = tab|default('description') %}
 
 
@@ -12,13 +13,7 @@
 {% block main_content %}
 <div class="row">
     <div class="card side-card text-center col-sm-4 col-md-3 col-lg-2">
-        {% if org.public_service %}
-        <img src="{{ theme_static('img/certified-stamp.png') }}" alt="certified"
-            class="certified" data-toggle="popover"
-            data-title="{{ _('Certified public service') }}"
-            data-content="{{_('The identity of this public service is certified by %(certifier)', certifier=config.SITE_AUTHOR)}}"
-            data-container="body" data-trigger="hover"/>
-        {% endif %}
+        {{ badge_if_certified(org) }}
         <a href="{{ url_for('organizations.show', org=org) }}"
             title="{{ org.name }}">
             <img src="{{ org.logo|placeholder('organization') }}"

--- a/udata/templates/organization/edit_base.html
+++ b/udata/templates/organization/edit_base.html
@@ -16,7 +16,7 @@
         <img src="{{ theme_static('img/certified-stamp.png') }}" alt="certified"
             class="certified" data-toggle="popover"
             data-title="{{ _('Certified public service') }}"
-            data-content="{{ _('The identity of this public service public is certified by Etalab') }}"
+            data-content="{{_('The identity of this public service is certified by %(certifier)', certifier=config.SITE_AUTHOR)}}"
             data-container="body" data-trigger="hover"/>
         {% endif %}
         <a href="{{ url_for('organizations.show', org=org) }}"

--- a/udata/templates/organization/search-result.html
+++ b/udata/templates/organization/search-result.html
@@ -1,4 +1,5 @@
 {% cache cache_duration, 'org-search-result', organization.id|string, g.lang_code %}
+{% from theme('macros/certified.html') import badge_if_certified with context %}
 <li class="search-result organization-result">
     <a href="{{ url_for('organizations.show', org=organization) }}" title="{{ organization.name }}">
         <div class="result-logo pull-left">
@@ -6,13 +7,7 @@
                 src="{{ organization.logo(70)|placeholder('organization') }}"
                 width="70" height="70">
         </div>
-        {% if organization.public_service %}
-        <img src="{{theme_static('img/certified-stamp.png')}}" alt="certified"
-            class="certified" data-toggle="popover"
-            data-title="{{ _('Certified public service') }}"
-            data-content="{{_('The identity of this public service is certified by %(certifier)', certifier=config.SITE_AUTHOR)}}"
-            data-container="body" data-placement="left" data-trigger="hover"/>
-        {% endif %}
+        {{ badge_if_certified(org) }}
         <div class="result-body ellipsis-dot">
             <h4 class="result-title">{{ organization.name }}</h4>
             <div class="result-description">

--- a/udata/templates/organization/search-result.html
+++ b/udata/templates/organization/search-result.html
@@ -7,7 +7,7 @@
                 src="{{ organization.logo(70)|placeholder('organization') }}"
                 width="70" height="70">
         </div>
-        {{ badge_if_certified(org) }}
+        {{ badge_if_certified(organization) }}
         <div class="result-body ellipsis-dot">
             <h4 class="result-title">{{ organization.name }}</h4>
             <div class="result-description">

--- a/udata/templates/organization/search-result.html
+++ b/udata/templates/organization/search-result.html
@@ -10,7 +10,7 @@
         <img src="{{theme_static('img/certified-stamp.png')}}" alt="certified"
             class="certified" data-toggle="popover"
             data-title="{{ _('Certified public service') }}"
-            data-content="{{ _('The identity of this public service public is certified by Etalab') }}"
+            data-content="{{_('The identity of this public service is certified by %(certifier)', certifier=config.SITE_AUTHOR)}}"
             data-container="body" data-placement="left" data-trigger="hover"/>
         {% endif %}
         <div class="result-body ellipsis-dot">


### PR DESCRIPTION
This replaces hard-coded references to Etalab with SITE_AUTHOR from the config. In practice, this is only used for certification badges.