### PR TITLE
Move the /terms route to the core, and move terms.html to the theme templates

### DIFF
--- a/udata/core/site/views.py
+++ b/udata/core/site/views.py
@@ -163,7 +163,13 @@ class SiteDashboard(SiteView, DetailView):
         return context
 
 
+@blueprint.route('/terms/')
+def terms():
+    return theme.render('terms.html')
+
+
 @sitemap.register_generator
 def site_sitemap_urls():
     yield 'site.home_redirect', {}, None, 'daily', 1
     yield 'site.dashboard_redirect', {}, None, 'weekly', 0.6
+    yield 'site.terms_redirect', {}, None, 'monthly', 0.2

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -72,6 +72,7 @@ class Defaults(object):
     SITE_AUTHOR_URL = None
     SITE_AUTHOR = 'Udata'
     SITE_GITHUB_URL = 'https://github.com/etalab/udata'
+    SITE_TERMS_URL = '/terms'
     USE_SSL = False
 
     PLUGINS = []

--- a/udata/settings.py
+++ b/udata/settings.py
@@ -72,7 +72,6 @@ class Defaults(object):
     SITE_AUTHOR_URL = None
     SITE_AUTHOR = 'Udata'
     SITE_GITHUB_URL = 'https://github.com/etalab/udata'
-    SITE_TERMS_URL = '/terms'
     USE_SSL = False
 
     PLUGINS = []

--- a/udata/templates/security/register_user.html
+++ b/udata/templates/security/register_user.html
@@ -18,7 +18,7 @@
                     </label>
                 </div>
                 <div class="col-xs-10 col-md-8 col-lg-9 text-left">
-                    <label>{{ _('I have read and accept <a href="%(url)s"> the terms and conditions of the service.</a>'), url='/terms' }}</label>
+                    <label>{{ _('I have read and accept <a href="%(url)s"> the terms and conditions of the service.</a>', url=config.SITE_GITHUB_URL) }}</label>
                     <br/>
                     {{ _('In particular, I understand that this site
                     values the production and enrichment of datasets over definitive or partisan interpretations.

--- a/udata/templates/security/register_user.html
+++ b/udata/templates/security/register_user.html
@@ -18,7 +18,7 @@
                     </label>
                 </div>
                 <div class="col-xs-10 col-md-8 col-lg-9 text-left">
-                    <label>{{ _('I have read and accept <a href="%(url)s"> the terms and conditions of the service.</a>', url=config.SITE_GITHUB_URL) }}</label>
+                    <label>{{ _('I have read and accept <a href="%(url)s"> the terms and conditions of the service.</a>', url=url_for('site.terms')) }}</label>
                     <br/>
                     {{ _('In particular, I understand that this site
                     values the production and enrichment of datasets over definitive or partisan interpretations.

--- a/udata/templates/terms.html
+++ b/udata/templates/terms.html
@@ -1,0 +1,22 @@
+{% extends theme("base.html") %}
+
+{% set meta = {
+    'title': _('Terms'),
+    'description': _('Terms'),
+    'keywords': [
+        'terms', _('terms'),
+    ],
+} %}
+
+{% block content %}
+<section class="content">
+    <div class="container">
+        <div class="page-header">
+            <h1>Generic terms and conditions</h1>
+        </div>
+        <div class="row">
+            <p>Be excellent to each other.</p>
+        </div>
+    </div>
+</section>
+{% endblock %}

--- a/udata/tests/site/test_site_views.py
+++ b/udata/tests/site/test_site_views.py
@@ -379,3 +379,7 @@ class SiteViewsTest(FrontTestCase):
     def test_map_view(self):
         response = self.get(url_for('site.map'))
         self.assert200(response)
+
+    def test_terms_view(self):
+        response = self.client.get(url_for('site.terms'))
+        self.assert200(response)

--- a/udata/tests/test_sitemap.py
+++ b/udata/tests/test_sitemap.py
@@ -131,3 +131,10 @@ class SitemapTest(SitemapTestCase):
         url = self.get_by_url('apidoc.swaggerui_redirect')
         self.assertIsNotNone(url)
         self.assert_url(url, 0.9, 'weekly')
+
+    def test_terms_within_sitemap(self):
+        '''It should return the terms page from the sitemap.'''
+        self.get_sitemap_tree()
+
+        url = self.get_by_url('site.terms_redirect')
+        self.assertIsNotNone(url)


### PR DESCRIPTION
References https://github.com/etalab/udata-gouvfr/pull/109