### PR TITLE
Document the OpenDataTeam migration

### DIFF
--- a/docs/adapting-settings.md
+++ b/docs/adapting-settings.md
@@ -104,7 +104,7 @@ for more details.
 
 ## Celery options
 
-By default, uData is configured to use Redis as Celery backend and a cutomized MongoDB scheduler.
+By default, uData is configured to use Redis as Celery backend and a customized MongoDB scheduler.
 
 The defaults are:
 

--- a/docs/adding-translations.md
+++ b/docs/adding-translations.md
@@ -38,5 +38,5 @@ Propose the new language on [Transifex][transifex-udata], once accepted you can:
 
 [transifex]: https://www.transifex.com
 [transifexrc]: http://docs.transifex.com/client/config/
-[transifex-udata]: https://www.transifex.com/etalab/udata/
+[transifex-udata]: https://www.transifex.com/opendatateam/udata/
 [famfamfam-flags]: http://www.famfamfam.com/lab/icons/flags/

--- a/docs/contributing-guide.md
+++ b/docs/contributing-guide.md
@@ -56,6 +56,9 @@ If you’re not familiar with open-source workflows or our set of technologies, 
 
 We’re trying to develop this project in the open as much as possible. We have a dedicated [Gitter channel][gitter] where we discuss each new strategic change and invite the community to give a valuable feedback. You’re encouraged to join and participate.
 
+We also [vote for new features](governance.md) in order to include the whole community in the process.
+
+
 ## Code guides
 
 ### Python style guide
@@ -87,4 +90,4 @@ We try to stay as close as possible to [CommonMark][] but use default [extension
 [code-guide]: http://codeguide.co/
 [commonmark]: http://commonmark.org/
 [extensions-mkdocs]: http://www.mkdocs.org/user-guide/writing-your-docs/
-[gitter]: https://gitter.im/etalab/udata
+[gitter]: https://gitter.im/opendatateam/udata

--- a/docs/creating-theme.md
+++ b/docs/creating-theme.md
@@ -8,4 +8,4 @@ Please report any difficulty you encounter with a dedicated [Github issue][githu
 
 
 [udata-gouvfr theme]: https://github.com/etalab/udata-gouvfr/
-[github-new-issue]: https://github.com/etalab/udata/issues/new
+[github-new-issue]: https://github.com/opendatateam/udata/issues/new

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,20 @@
+# Governance
+
+The project has been initiated by the [French government team][etalab] and is now used by other countries (Luxembourg, Serbia, you?). In May 2016, we have moved the project to its own dedicated Github organization to reflect the fact that it’s an international effort and as such should be fully developed in the open.
+
+## Features
+
+Features are [prioritized on FeatHub][feathub] every contributor having an equal voice to vote.
+
+## Bugs
+
+Bugs are [reported directly on Github][github-new-issue] following the proposed template.
+
+## Discussion
+
+For daily chat, development discussions and so on we idle on [Gitter][gitter].
+
+[etalab]: https://github.com/etalab
+[feathub]: http://feathub.com/
+[github-new-issue]: https://github.com/opendatateam/udata/issues/new
+[gitter]: https://gitter.im/opendatateam/udata

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,14 +17,16 @@ Once the project is up and running, it's time to customize it! Take a look at ou
 
 The project is currently [in production for France][data-gouv-fr] and [in development for Luxembourg][data-gouv-lu-repository]. We can help you to set up your infrastructure, you can contact the team via [a Github issue][github-new-issue] or [through Gitter to chat directly][gitter].
 
+Take a look at the [governance](governance.md) section to know how we deal with feature voting from all the community.
+
 
 ## I found a bug or I want to propose an improvement
 
 For a bug, please [report it directly as a Github issue][github-new-issue] following the proposed template. We’ll answer you as soon as possible.
 
-For a contribution as a enthousiast citizen, check out our [contributing guide](contributing-guide.md). It's good to have you on board!
+For a contribution as a enthusiastic citizen, check out our [contributing guide](contributing-guide.md). It's good to have you on board!
 
 [data-gouv-fr]: https://www.data.gouv.fr/
 [data-gouv-lu-repository]: https://github.com/opendatalu/udata-gouvlu
-[github-new-issue]: https://github.com/etalab/udata/issues/new
-[gitter]: https://gitter.im/etalab/udata
+[github-new-issue]: https://github.com/opendatateam/udata/issues/new
+[gitter]: https://gitter.im/opendatateam/udata

--- a/docs/running-project.md
+++ b/docs/running-project.md
@@ -33,4 +33,4 @@ $ inv i18nc
 That's it! Now check out our advanced documentation for more customization.
 
 [dev-server]: http://localhost:7000/
-[gitter]: https://gitter.im/etalab/udata
+[gitter]: https://gitter.im/opendatateam/udata

--- a/docs/system-dependencies.md
+++ b/docs/system-dependencies.md
@@ -12,7 +12,7 @@ If you prefer [Homebrew][] (OSX), the package is named `git`.
 The sources of the project are on [Github][]:
 
 ```shell
-$ git clone https://github.com/etalab/udata.git
+$ git clone https://github.com/opendatateam/udata.git
 ```
 
 
@@ -77,8 +77,8 @@ But first, let's install [local dependencies](local-dependencies.md)!
 [elasticsearch]: https://www.elastic.co/products/elasticsearch
 [redis]: http://redis.io/
 [honcho]: https://github.com/nickstenning/honcho
-[gitter]: https://gitter.im/etalab/udata
-[github]: https://github.com/etalab/udata
+[gitter]: https://gitter.im/opendatateam/udata
+[github]: https://github.com/opendatateam/udata
 [homebrew]: http://brew.sh/
 [python]: https://www.python.org/
 [git]: https://git-scm.com/

--- a/docs/testing-code.md
+++ b/docs/testing-code.md
@@ -44,7 +44,7 @@ $ inv jstest
 
 It will run a single test pass using PhantomJS as browser.
 
-You can continously run the test on any change detected by using the `--watch` option:
+You can run the tests continuously as changed are detected by the `--watch` option:
 
 ```shell
 $ inv jstest --watch
@@ -78,7 +78,7 @@ See [the official karma documentation][karma] for more details about the possibl
 ### Testing on IE
 
 You can run the test suite under Modern.ie VMs installed with either [ievms][]
-or [iectrl][] (installation is detailled on websites).
+or [iectrl][] (installation is detailed on websites).
 
 ```bash
 # Install IE11 under Win7 (time to have one or more coffee!)
@@ -88,8 +88,8 @@ $ npm -s run test:unit -- --browsers 'IE11 - Win7'
 ```
 
 !!! note
-    uData ensure compatibility for IE [officialy supported by Microsoft][ie-support].
-    Right now, it's IE11.
+    uData tests ensure the compatibility with IE version(s) [officially supported by Microsoft][ie-support].
+    Right now, it’s IE11.
 
 You maybe need to manually close the first time popup on first run.
 To do so, launch the VM then launch the test suite:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,7 +18,9 @@ pages:
         - Adding translations: adding-translations.md
         - Creating a custom theme: creating-theme.md
         - Building the documentation: building-documentation.md
-    - Contributing: contributing-guide.md
+    - Contributing:
+        - Guide: contributing-guide.md
+        - Governance: governance.md
 
 markdown_extensions:
     - smarty


### PR DESCRIPTION
Update the documentation related to the move from https://github.com/etalab to https://github.com/opendatateam